### PR TITLE
Add c2pa-types + typed activeManifest and manifestStore APIs

### DIFF
--- a/.changeset/five-rice-raise.md
+++ b/.changeset/five-rice-raise.md
@@ -1,0 +1,7 @@
+---
+'@contentauth/c2pa-types': minor
+'@contentauth/c2pa-wasm': minor
+'@contentauth/c2pa-web': minor
+---
+
+Added reader.manifestStore() and reader.activeManifest() APIs

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -359,6 +359,7 @@ dependencies = [
  "riff",
  "ring",
  "rsa",
+ "schemars 0.8.22",
  "serde",
  "serde-transcode",
  "serde-wasm-bindgen",
@@ -392,6 +393,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "c2pa-types"
+version = "0.1.0"
+dependencies = [
+ "c2pa",
+ "schemars 0.8.22",
+ "serde_json",
+]
+
+[[package]]
 name = "c2pa-wasm"
 version = "0.1.0"
 dependencies = [
@@ -401,6 +411,8 @@ dependencies = [
  "console_log",
  "js-sys",
  "log",
+ "serde",
+ "serde-wasm-bindgen",
  "thiserror 2.0.12",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -2625,6 +2637,18 @@ dependencies = [
 
 [[package]]
 name = "schemars"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+dependencies = [
+ "dyn-clone",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
@@ -2645,6 +2669,18 @@ dependencies = [
  "ref-cast",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "0.8.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -2727,10 +2763,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_json"
-version = "1.0.141"
+name = "serde_derive_internals"
+version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30b9eff21ebe718216c6ec64e1d9ac57087aad11efc64e32002bce4a0d4c03d3"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.104",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.143"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d401abef1d108fbd9cbaebc3e46611f4b1021f714a0597a71f41ee463f5f4a5a"
 dependencies = [
  "indexmap 2.10.0",
  "itoa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 resolver = '2'
 members = [
 	'packages/c2pa-wasm',
+	'packages/c2pa-types',
 ]
 
 [profile.release]

--- a/packages/c2pa-types/.gitignore
+++ b/packages/c2pa-types/.gitignore
@@ -1,0 +1,2 @@
+schemas
+types

--- a/packages/c2pa-types/Cargo.toml
+++ b/packages/c2pa-types/Cargo.toml
@@ -4,6 +4,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-c2pa = { version = "0.58.0", features = ["pdf", "rust_native_crypto", "json_schema"], default-features = false }
+c2pa = { version = "0.62.0", features = ["pdf", "rust_native_crypto", "json_schema"], default-features = false }
 schemars = "0.8.21"
 serde_json = "1.0.143"

--- a/packages/c2pa-types/Cargo.toml
+++ b/packages/c2pa-types/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "c2pa-types"
+version = "0.1.0"
+edition = "2024"
+
+[dependencies]
+c2pa = { version = "0.58.0", features = ["pdf", "rust_native_crypto", "json_schema"], default-features = false }
+schemars = "0.8.21"
+serde_json = "1.0.143"

--- a/packages/c2pa-types/index.d.ts
+++ b/packages/c2pa-types/index.d.ts
@@ -1,0 +1,15 @@
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+
+import type { Reader } from './types/ManifestStore.js';
+
+// Renames the auto-generated "Reader" type to the more appropriate "ManifestStore"
+export interface ManifestStore extends Reader {}
+
+export type { Manifest } from './types/ManifestStore.js';

--- a/packages/c2pa-types/index.d.ts
+++ b/packages/c2pa-types/index.d.ts
@@ -10,6 +10,7 @@
 import type { Reader } from './types/ManifestStore.js';
 
 // Renames the auto-generated "Reader" type to the more appropriate "ManifestStore"
+// eslint-disable-next-line @typescript-eslint/no-empty-interface, @typescript-eslint/no-empty-object-type
 export interface ManifestStore extends Reader {}
 
 export type { Manifest } from './types/ManifestStore.js';

--- a/packages/c2pa-types/package.json
+++ b/packages/c2pa-types/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@contentauth/c2pa-types",
+  "description": "Typescript types generated from c2pa-rs",
+  "type": "module",
+  "version": "0.1.1",
+  "types": "index.d.ts",
+  "scripts": {
+    "test": "echo \"No tests to run\" && exit 0",
+    "build": "pnpm clean && json2ts -i schemas/ -o types/",
+    "clean": "rimraf types"
+  },
+  "files": ["index.d.ts", "types/**/*"],
+  "dependencies": {
+    "json-schema-to-typescript": "^15.0.4",
+    "rimraf": "^6.0.1"
+  }
+}

--- a/packages/c2pa-types/project.json
+++ b/packages/c2pa-types/project.json
@@ -1,0 +1,26 @@
+{
+  "name": "c2pa-types",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "tags": ["lib"],
+  "projectType": "library",
+  "sourceRoot": "packages/c2pa-types/src",
+  "targets": {
+    "build": {
+      "cache": true,
+      "inputs": [
+        "{projectRoot}/**/*",
+        "!{projectRoot}/schemas/**/*",
+        "!{projectRoot}/types/**/*"
+      ],
+      "executor": "nx:run-commands",
+      "options": {
+        "commands": [
+          "cargo run",
+          "pnpm build"
+        ],
+        "parallel": false,
+        "cwd": "{projectRoot}"
+      }
+    }
+  }
+}

--- a/packages/c2pa-types/src/main.rs
+++ b/packages/c2pa-types/src/main.rs
@@ -1,0 +1,20 @@
+use std::{fs, path::Path};
+
+use c2pa::Reader;
+use schemars::{schema::RootSchema, schema_for};
+
+fn main() {
+    let output_dir = Path::new("./schemas");
+    fs::remove_dir_all(output_dir).expect("Could not clear existing schema directory");
+    fs::create_dir_all(output_dir).expect("Could not create schema directory");
+
+    write_schema(&schema_for!(Reader), &"ManifestStore", output_dir);
+}
+
+fn write_schema(schema: &RootSchema, name: &str, output_dir: &Path) {
+    println!("Exporting JSON schema for {name}");
+    let output_path = output_dir.join(format!("{name}.json"));
+    let output = serde_json::to_string_pretty(schema).expect("Failed to serialize schema");
+    fs::write(&output_path, output).expect("Unable to write schema");
+    println!("Wrote schema to {}", output_path.display());
+}

--- a/packages/c2pa-types/src/main.rs
+++ b/packages/c2pa-types/src/main.rs
@@ -1,3 +1,10 @@
+// Copyright 2025 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in
+// accordance with the terms of the Adobe license agreement accompanying
+// it.
+
 use std::{fs, path::Path};
 
 use c2pa::Reader;

--- a/packages/c2pa-types/src/main.rs
+++ b/packages/c2pa-types/src/main.rs
@@ -5,7 +5,11 @@ use schemars::{schema::RootSchema, schema_for};
 
 fn main() {
     let output_dir = Path::new("./schemas");
-    fs::remove_dir_all(output_dir).expect("Could not clear existing schema directory");
+
+    if fs::exists(output_dir).unwrap() {
+        fs::remove_dir_all(output_dir).expect("Could not clear existing schema directory");
+    }
+
     fs::create_dir_all(output_dir).expect("Could not create schema directory");
 
     write_schema(&schema_for!(Reader), &"ManifestStore", output_dir);

--- a/packages/c2pa-wasm/Cargo.toml
+++ b/packages/c2pa-wasm/Cargo.toml
@@ -25,6 +25,8 @@ wasm-bindgen-futures = "0.4.50"
 c2pa = { version = "0.62.0", features = ["pdf", "rust_native_crypto", "fetch_remote_manifests"], default-features = false }
 async-trait = "0.1.88"
 thiserror = "2.0.12"
+serde-wasm-bindgen = "0.6.5"
+serde = "1.0.219"
 
 [dependencies.web-sys]
 version = "0.3.77"

--- a/packages/c2pa-wasm/src/error.rs
+++ b/packages/c2pa-wasm/src/error.rs
@@ -15,6 +15,9 @@ pub enum WasmError {
     C2pa(#[from] c2pa::Error),
 
     #[error(transparent)]
+    Serde(#[from] serde_wasm_bindgen::Error),
+
+    #[error(transparent)]
     Other(Box<dyn Error>),
 }
 

--- a/packages/c2pa-web/package.json
+++ b/packages/c2pa-web/package.json
@@ -30,7 +30,8 @@
     }
   },
   "dependencies": {
-    "@contentauth/c2pa-wasm": "workspace:*"
+    "@contentauth/c2pa-wasm": "workspace:*",
+    "@contentauth/c2pa-types": "workspace:*"
   },
   "devDependencies": {
     "@playwright/test": "^1.55.0",

--- a/packages/c2pa-web/src/index.ts
+++ b/packages/c2pa-web/src/index.ts
@@ -8,8 +8,13 @@
  */
 
 export * from './lib/c2pa.js';
+
 export {
   isSupportedReaderFormat,
   READER_SUPPORTED_FORMATS,
 } from './lib/supportedFormats.js';
+
 export { type Settings } from './lib/settings.js';
+
+// Re-export types from c2pa-types for convenience.
+export type * from '@contentauth/c2pa-types';

--- a/packages/c2pa-web/src/lib/c2pa.spec.ts
+++ b/packages/c2pa-web/src/lib/c2pa.spec.ts
@@ -35,7 +35,7 @@ describe('c2pa', () => {
 
       const reader = await c2pa.reader.fromBlob(blob.type, blob);
 
-      const manifestStore = await reader.manifestStore();
+      const manifestStore = await reader.json();
 
       expect(manifestStore).toEqual(C_with_CAWG_data_ManifestStore);
 
@@ -49,11 +49,11 @@ describe('c2pa', () => {
 
       const reader = await c2pa.reader.fromBlob(blob.type, blob);
 
-      const manifestStore = await reader.manifestStore();
+      const manifestStore = await reader.json();
 
       const activeManifest =
-        manifestStore.manifests[manifestStore.active_manifest];
-      const thumbnailId = activeManifest.thumbnail.identifier;
+        manifestStore.manifests[manifestStore.active_manifest!];
+      const thumbnailId = activeManifest.thumbnail!.identifier;
 
       const thumbnailBuffer = await reader.resourceToBuffer(thumbnailId);
       const thumbnail = new Uint8Array(thumbnailBuffer!);
@@ -100,7 +100,7 @@ describe('c2pa', () => {
 
       const reader = await c2pa.reader.fromBlob(blob.type, blob);
 
-      const manifestStore = await reader.manifestStore();
+      const manifestStore = await reader.json();
 
       expect(manifestStore).toEqual(C_with_CAWG_data_trusted_ManifestStore);
 
@@ -123,7 +123,7 @@ describe('c2pa', () => {
 
       const reader = await c2pa.reader.fromBlob(blob.type, blob);
 
-      const manifestStore = await reader.manifestStore();
+      const manifestStore = await reader.json();
 
       expect(manifestStore).toEqual(C_with_CAWG_data_untrusted_ManifestStore);
 
@@ -142,7 +142,7 @@ describe('c2pa', () => {
         fragmentBlob
       );
 
-      const manifestStore = await reader.manifestStore();
+      const manifestStore = await reader.json();
 
       expect(manifestStore).toEqual(dashinit_ManifestStore);
 
@@ -159,7 +159,7 @@ describe('c2pa', () => {
 
       await reader.free();
 
-      await expect(reader.manifestStore()).rejects.toThrowError();
+      await expect(reader.json()).rejects.toThrowError();
     });
   });
 });

--- a/packages/c2pa-web/src/lib/worker.ts
+++ b/packages/c2pa-web/src/lib/worker.ts
@@ -49,13 +49,21 @@ const workerFunctions = {
   },
 
   // Reader object methods
-  reader_json(readerId: number): WorkerResponse<string> {
-    const reader = readerMap.get(readerId);
-    return { data: reader.json() };
-  },
   reader_activeLabel(readerId: number): WorkerResponse<string | null> {
     const reader = readerMap.get(readerId);
     return { data: reader.activeLabel() ?? null };
+  },
+  reader_manifestStore(readerId: number): WorkerResponse<any> {
+    const reader = readerMap.get(readerId);
+    return { data: reader.manifestStore() };
+  },
+  reader_activeManifest(readerId: number): WorkerResponse<any> {
+    const reader = readerMap.get(readerId);
+    return { data: reader.activeManifest() };
+  },
+  reader_json(readerId: number): WorkerResponse<string> {
+    const reader = readerMap.get(readerId);
+    return { data: reader.json() };
   },
   reader_resourceToBuffer(
     readerId: number,

--- a/packages/c2pa-web/vite.config.ts
+++ b/packages/c2pa-web/vite.config.ts
@@ -41,7 +41,7 @@ export default defineConfig(() => ({
     },
     rollupOptions: {
       // External packages that should not be bundled into your library.
-      external: [],
+      external: ['@contentauth/c2pa-types'],
     },
   },
   server: {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,10 +102,22 @@ importers:
         specifier: ^3.0.0
         version: 3.2.4(@types/node@18.16.9)(@vitest/browser@3.2.4)(@vitest/ui@3.2.4)(jiti@2.4.2)(jsdom@22.1.0)(terser@5.43.1)(yaml@2.8.0)
 
+  packages/c2pa-types:
+    dependencies:
+      json-schema-to-typescript:
+        specifier: ^15.0.4
+        version: 15.0.4
+      rimraf:
+        specifier: ^6.0.1
+        version: 6.0.1
+
   packages/c2pa-wasm: {}
 
   packages/c2pa-web:
     dependencies:
+      '@contentauth/c2pa-types':
+        specifier: workspace:*
+        version: link:../c2pa-types
       '@contentauth/c2pa-wasm':
         specifier: workspace:*
         version: link:../c2pa-wasm
@@ -158,6 +170,10 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@apidevtools/json-schema-ref-parser@11.9.3':
+    resolution: {integrity: sha512-60vepv88RwcJtSHrD6MjIL6Ta3SOYbgfnkHb+ppAVK+o9mXprRtulx7VlRl3lN3bbvysAfCS7WMVfhUYemB0IQ==}
+    engines: {node: '>= 16'}
 
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
@@ -1293,6 +1309,9 @@ packages:
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
+  '@jsdevtools/ono@7.1.3':
+    resolution: {integrity: sha512-4JQNk+3mVzK3xh2rqd6RB4J46qUR19azEHBneZyTZM+c456qOrbbM/5xcR8huNCCcbVt7+UmizG6GuUvPvKUYg==}
+
   '@ltd/j-toml@1.38.0':
     resolution: {integrity: sha512-lYtBcmvHustHQtg4X7TXUu1Xa/tbLC3p2wLvgQI+fWVySguVZJF60Snxijw5EiohumxZbR10kWYFFebh1zotiw==}
 
@@ -2266,6 +2285,9 @@ packages:
 
   '@types/jsonfile@6.1.4':
     resolution: {integrity: sha512-D5qGUYwjvnNNextdU59/+fI+spnwtTFmyQP0h+PfIOSkNfpU6AOICUOkm4i0OnSk+NyjdPJrxCDro0sJsWlRpQ==}
+
+  '@types/lodash@4.17.20':
+    resolution: {integrity: sha512-H3MHACvFUEiujabxhaI/ImO6gUrd8oOurg7LQtS7mbwIXA/cUqWrvBsaeJ23aZEPk1TAYkurjfMbSELfoCXlGA==}
 
   '@types/node@12.20.55':
     resolution: {integrity: sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==}
@@ -3858,6 +3880,11 @@ packages:
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
 
+  json-schema-to-typescript@15.0.4:
+    resolution: {integrity: sha512-Su9oK8DR4xCmDsLlyvadkXzX6+GGXJpbhwoLtOGArAG61dvbW4YQmSEno2y66ahpIdmLMg6YUf/QHLgiwvkrHQ==}
+    engines: {node: '>=16.0.0'}
+    hasBin: true
+
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
 
@@ -4314,6 +4341,11 @@ packages:
   prettier@2.8.8:
     resolution: {integrity: sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==}
     engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  prettier@3.6.2:
+    resolution: {integrity: sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==}
+    engines: {node: '>=14'}
     hasBin: true
 
   pretty-format@27.5.1:
@@ -5087,6 +5119,12 @@ snapshots:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
       '@jridgewell/trace-mapping': 0.3.29
+
+  '@apidevtools/json-schema-ref-parser@11.9.3':
+    dependencies:
+      '@jsdevtools/ono': 7.1.3
+      '@types/json-schema': 7.0.15
+      js-yaml: 4.1.0
 
   '@babel/code-frame@7.27.1':
     dependencies:
@@ -6477,6 +6515,8 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
 
+  '@jsdevtools/ono@7.1.3': {}
+
   '@ltd/j-toml@1.38.0': {}
 
   '@manypkg/find-root@1.1.0':
@@ -7509,6 +7549,8 @@ snapshots:
   '@types/jsonfile@6.1.4':
     dependencies:
       '@types/node': 18.16.9
+
+  '@types/lodash@4.17.20': {}
 
   '@types/node@12.20.55': {}
 
@@ -9412,6 +9454,18 @@ snapshots:
 
   json-parse-even-better-errors@2.3.1: {}
 
+  json-schema-to-typescript@15.0.4:
+    dependencies:
+      '@apidevtools/json-schema-ref-parser': 11.9.3
+      '@types/json-schema': 7.0.15
+      '@types/lodash': 4.17.20
+      is-glob: 4.0.3
+      js-yaml: 4.1.0
+      lodash: 4.17.21
+      minimist: 1.2.8
+      prettier: 3.6.2
+      tinyglobby: 0.2.14
+
   json-schema-traverse@0.4.1: {}
 
   json-schema-traverse@1.0.0: {}
@@ -9856,6 +9910,8 @@ snapshots:
   prelude-ls@1.2.1: {}
 
   prettier@2.8.8: {}
+
+  prettier@3.6.2: {}
 
   pretty-format@27.5.1:
     dependencies:


### PR DESCRIPTION
- Add c2pa-types package with logic to automatically generate TS types from c2pa-rs using schemars and json-schema-to-typescript.
- Add activeManifest and manifestStore methods to the reader, taking advantage of these shiny new types for their output.