### PR TITLE
fix(c2pa-web): change the unregister token passed to FinalizationRegistry.register

### DIFF
--- a/.changeset/chilly-schools-behave.md
+++ b/.changeset/chilly-schools-behave.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-web': patch
+---
+
+Fix issue which crashes reader.fromBlob() and reader.fromBlobFragment() in Firefox.

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,6 +5,7 @@ runs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         target: wasm32-unknown-unknown
+        components: clippy
 
     - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         name: Install dependencies
 
       # Install chrome + chromedriver for vitest + wasm-pack test
-      - run: pnpx playwright install --with-deps
+      - name: Install headless Chromium + Chromedriver
+        working-directory: ./packages/c2pa-web
+        run: pnpm exec playwright install --with-deps
 
       - run: pnpm exec nx run-many -t lint test build --projects=tag:lib

--- a/packages/c2pa-web/src/lib/reader.ts
+++ b/packages/c2pa-web/src/lib/reader.ts
@@ -118,11 +118,10 @@ export function createReaderFactory(worker: WorkerManager): ReaderFactory {
         args: [format, blob],
       });
 
-      const unregisterToken = Symbol(readerId);
       const reader = createReader(worker, readerId, () => {
-        registry.unregister(unregisterToken);
+        registry.unregister(reader);
       });
-      registry.register(reader, readerId, unregisterToken);
+      registry.register(reader, readerId, reader);
 
       return reader;
     },
@@ -141,11 +140,10 @@ export function createReaderFactory(worker: WorkerManager): ReaderFactory {
         args: [format, init, fragment],
       });
 
-      const unregisterToken = Symbol(readerId);
       const reader = createReader(worker, readerId, () => {
-        registry.unregister(unregisterToken);
+        registry.unregister(reader);
       });
-      registry.register(reader, readerId, unregisterToken);
+      registry.register(reader, readerId, reader);
 
       return reader;
     },


### PR DESCRIPTION
Running `c2pa-web` in `FF 143.0.1` throws the following error:
```
TypeError: Invalid unregister token passed to FinalizationRegistry.register
```

Change the unregister token to be the reader reference itself, instead of a `Symbol`.
This should work because the unregister token is only weakly-referenced by the registry, as per [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry).