### PR TITLE
ci: fix flakiness

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -5,6 +5,7 @@ runs:
     - uses: dtolnay/rust-toolchain@stable
       with:
         target: wasm32-unknown-unknown
+        components: clippy
 
     - uses: Swatinem/rust-cache@v2
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
         name: Install dependencies
 
       # Install chrome + chromedriver for vitest + wasm-pack test
-      - run: pnpx playwright install --with-deps
+      - name: Install headless Chromium + Chromedriver
+        working-directory: ./packages/c2pa-web
+        run: pnpm exec playwright install --with-deps
 
       - run: pnpm exec nx run-many -t lint test build --projects=tag:lib


### PR DESCRIPTION
- Explicitly install clippy (why was this working before?)
- Install playwright headless browser dependencies based on installed version in c2pa-web