### PR TITLE
docs: clarify installing JS packages via pnpm

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # c2pa-js
 
-> [!NOTE]  
+> [!NOTE]
 > Looking for the old `c2pa-js` repo? It's available [here](https://github.com/contentauth/c2pa-js-legacy) as `c2pa-js-legacy`. Those packages are now deprecated and implementors wishing to interact with C2PA metadata on the web should use the libraries in this repo instead.
 
 A collection of libraries and tools that enable interaction with [C2PA metadata](https://c2pa.org/) in JavaScript. Part of the [Content Authenticity Initiative](https://contentauthenticity.org/).
@@ -11,7 +11,7 @@ This monorepo is managed by [NX](https://nx.dev/getting-started/intro) and [pnpm
 
 ```sh
 npm install -g pnpm
-pnpm install -g nx
+pnpm install
 ```
 
 Commands are run in the following format: `nx [target] [project]`, e.g.:


### PR DESCRIPTION
This PR clarifies the build from source step with `pnpm`.

For more context, `nx build c2pa-web` by itself will suggest running `npm/yarn install` and `npm install` fails with this error:
```bash
npm warn Unknown project config "strict-peer-dependencies". This will stop working in the next major version of npm.
npm warn Unknown project config "auto-install-peers". This will stop working in the next major version of npm.
npm warn ERESOLVE overriding peer dependency
npm warn deprecated inflight@1.0.6: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
npm warn deprecated abab@2.0.6: Use your platform's native atob() and btoa() methods instead
npm warn deprecated glob@7.2.3: Glob versions prior to v9 are no longer supported
npm warn deprecated domexception@4.0.0: Use your platform's native DOMException instead
npm warn cleanup Failed to remove some directories [
npm warn cleanup   [
npm warn cleanup     '/Users/nicky/open-work-repos/c2pa-js/node_modules/@swc/core',
npm warn cleanup     [Error: ENOTEMPTY: directory not empty, rmdir '/Users/nicky/open-work-repos/c2pa-js/node_modules/@swc/core'] {
npm warn cleanup       errno: -66,
npm warn cleanup       code: 'ENOTEMPTY',
npm warn cleanup       syscall: 'rmdir',
npm warn cleanup       path: '/Users/nicky/open-work-repos/c2pa-js/node_modules/@swc/core'
npm warn cleanup     }
npm warn cleanup   ]
npm warn cleanup ]
npm error code 127
npm error path /Users/nicky/open-work-repos/c2pa-js/node_modules/rollup
npm error command failed
npm error command sh -c patch-package
npm error sh: line 1: patch-package: command not found
npm error A complete log of this run can be found in: /Users/nicky/.npm/_logs/2025-11-07T18_03_08_118Z-debug-0.log
```