### PR TITLE
feat: add TSA and certificate support to wasm signer

### DIFF
--- a/.changeset/smart-impalas-eat.md
+++ b/.changeset/smart-impalas-eat.md
@@ -1,0 +1,6 @@
+---
+'@contentauth/c2pa-wasm': minor
+'@contentauth/c2pa-web': minor
+---
+
+Add TSA and certificate support to WASM signer. Allow configuration of direct COSE handling.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,11 +428,13 @@ name = "c2pa-wasm"
 version = "0.1.0"
 dependencies = [
  "async-trait",
+ "base64 0.22.1",
  "c2pa",
  "console_error_panic_hook",
  "console_log",
  "js-sys",
  "log",
+ "pem",
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,7 +428,7 @@ name = "c2pa-wasm"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "base64 0.22.1",
+ "base64",
  "c2pa",
  "console_error_panic_hook",
  "console_log",

--- a/package.json
+++ b/package.json
@@ -44,5 +44,5 @@
     "vite-plugin-dts": "~4.5.0",
     "vitest": "^3.0.0"
   },
-  "packageManager": "pnpm@10.15.0"
+  "packageManager": "pnpm@10.33.2"
 }

--- a/packages/c2pa-wasm/Cargo.toml
+++ b/packages/c2pa-wasm/Cargo.toml
@@ -27,6 +27,8 @@ thiserror = "2.0.12"
 serde-wasm-bindgen = "0.6.5"
 serde = "1.0.219"
 serde_bytes = "0.11.19"
+base64 = "0.22.1"
+pem = "3.0.4"
 
 [dependencies.web-sys]
 version = "0.3.77"

--- a/packages/c2pa-wasm/src/wasm_signer.rs
+++ b/packages/c2pa-wasm/src/wasm_signer.rs
@@ -6,11 +6,16 @@
 // it.
 
 use async_trait::async_trait;
+use base64::Engine as _;
+use c2pa::crypto::time_stamp::default_rfc3161_message;
 use c2pa::SigningAlg;
 use c2pa::{AsyncSigner, Result as C2paResult};
-use js_sys::{Function as JsFunction, JsString, Number, Promise as JsPromise, Reflect, Uint8Array};
-use wasm_bindgen::JsValue;
+use js_sys::{
+    Array, ArrayBuffer, Function as JsFunction, JsString, Number,
+    Promise as JsPromise, Reflect, Uint8Array,
+};
 use wasm_bindgen::prelude::*;
+use wasm_bindgen::{JsCast, JsValue};
 use wasm_bindgen_futures::JsFuture;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -19,6 +24,11 @@ interface SignerDefinition {
     sign: (bytes: Uint8Array<ArrayBuffer>) => Promise<Uint8Array<ArrayBuffer>>;
     reserveSize: number;
     alg: string;
+    certs?: Array<Uint8Array<ArrayBuffer> | string>;
+    directCoseHandling?: boolean;
+    tsaUrl?: string;
+    tsaHeaders?: Array<[string, string]>;
+    tsaBody?: Uint8Array<ArrayBuffer> | string;
 }
 "#;
 
@@ -35,6 +45,11 @@ pub(crate) struct WasmSigner {
     sign_fn: JsFunction,
     reserve_size: f64,
     signing_alg: SigningAlg,
+    cert_chain: Vec<Vec<u8>>,
+    direct_cose_handling: bool,
+    tsa_url: Option<String>,
+    tsa_headers: Vec<(String, String)>,
+    tsa_body: Option<Vec<u8>>,
 }
 
 /**
@@ -64,11 +79,30 @@ impl WasmSigner {
         };
 
         let sign_fn: JsFunction = Reflect::get(&js_value, &"sign".into())?.into();
+        let certs_value = Reflect::get(&js_value, &"certs".into())?;
+        let cert_chain = parse_cert_chain(certs_value)?;
+
+        let direct_cose_value = Reflect::get(&js_value, &"directCoseHandling".into())?;
+        let direct_cose_handling = direct_cose_value.as_bool().unwrap_or(false);
+
+        let tsa_url_value = Reflect::get(&js_value, &"tsaUrl".into())?;
+        let tsa_url = parse_optional_string(tsa_url_value)?;
+
+        let tsa_headers_value = Reflect::get(&js_value, &"tsaHeaders".into())?;
+        let tsa_headers = parse_tsa_headers(tsa_headers_value)?;
+
+        let tsa_body_value = Reflect::get(&js_value, &"tsaBody".into())?;
+        let tsa_body = parse_optional_body(tsa_body_value)?;
 
         Ok(WasmSigner {
             reserve_size: reserve_size_result.into(),
             signing_alg,
             sign_fn,
+            cert_chain,
+            direct_cose_handling,
+            tsa_url,
+            tsa_headers,
+            tsa_body,
         })
     }
 }
@@ -105,8 +139,7 @@ impl AsyncSigner for WasmSigner {
     }
 
     fn certs(&self) -> C2paResult<Vec<Vec<u8>>> {
-        // @TODO: make configurable
-        Ok(Vec::new())
+        Ok(self.cert_chain.clone())
     }
 
     fn reserve_size(&self) -> usize {
@@ -114,7 +147,206 @@ impl AsyncSigner for WasmSigner {
     }
 
     fn direct_cose_handling(&self) -> bool {
-        // @TODO: make configurable
-        true
+        self.direct_cose_handling
+    }
+
+    fn time_authority_url(&self) -> Option<String> {
+        self.tsa_url.clone()
+    }
+
+    fn timestamp_request_headers(&self) -> Option<Vec<(String, String)>> {
+        if self.tsa_headers.is_empty() {
+            None
+        } else {
+            Some(self.tsa_headers.clone())
+        }
+    }
+
+    fn timestamp_request_body(&self, message: &[u8]) -> C2paResult<Vec<u8>> {
+        if let Some(body) = &self.tsa_body {
+            return Ok(body.clone());
+        }
+
+        default_rfc3161_message(message).map_err(|err| err.into())
+    }
+}
+
+fn parse_cert_chain(value: JsValue) -> Result<Vec<Vec<u8>>, JsString> {
+    if value.is_undefined() || value.is_null() {
+        return Ok(Vec::new());
+    }
+
+    if !Array::is_array(&value) {
+        return Err(JsString::from(
+            "SignerDefinition.certs must be an array of PEM strings or binary buffers",
+        ));
+    }
+
+    let array = Array::from(&value);
+    let mut certs: Vec<Vec<u8>> = Vec::with_capacity(array.length() as usize);
+
+    for (index, entry) in array.iter().enumerate() {
+        certs.extend(parse_cert_entry(entry, index)?);
+    }
+
+    Ok(certs)
+}
+
+fn parse_cert_entry(value: JsValue, index: usize) -> Result<Vec<Vec<u8>>, JsString> {
+    if let Some(pem) = value.as_string() {
+        return decode_pem_or_base64(&pem).map_err(|message| {
+            JsString::from(&format!("Failed to decode certificate at index {index}: {message}"))
+        });
+    }
+
+    if value.is_instance_of::<Uint8Array>() {
+        let bytes: Uint8Array = value.unchecked_into();
+        return decode_cert_from_bytes(bytes.to_vec(), index);
+    }
+
+    if value.is_instance_of::<ArrayBuffer>() {
+        let buffer: ArrayBuffer = value.unchecked_into();
+        let bytes = Uint8Array::new(&buffer);
+        return decode_cert_from_bytes(bytes.to_vec(), index);
+    }
+
+    if ArrayBuffer::is_view(&value) {
+        let view = Uint8Array::new(&value);
+        return decode_cert_from_bytes(view.to_vec(), index);
+    }
+
+    Err(JsString::from(&format!(
+        "Unsupported certificate value at index {index}; expected a PEM string or ArrayBuffer",
+    )))
+}
+
+fn parse_optional_string(value: JsValue) -> Result<Option<String>, JsString> {
+    if value.is_undefined() || value.is_null() {
+        return Ok(None);
+    }
+
+    value
+        .as_string()
+        .map(Some)
+        .ok_or_else(|| JsString::from("SignerDefinition.tsaUrl must be a string"))
+}
+
+fn parse_tsa_headers(value: JsValue) -> Result<Vec<(String, String)>, JsString> {
+    if value.is_undefined() || value.is_null() {
+        return Ok(Vec::new());
+    }
+
+    if !Array::is_array(&value) {
+        return Err(JsString::from(
+            "SignerDefinition.tsaHeaders must be an array of [key, value] tuples",
+        ));
+    }
+
+    let headers_array = Array::from(&value);
+    let mut headers: Vec<(String, String)> = Vec::with_capacity(headers_array.length() as usize);
+
+    for (index, entry) in headers_array.iter().enumerate() {
+        if !Array::is_array(&entry) {
+            return Err(JsString::from(&format!(
+                "SignerDefinition.tsaHeaders[{index}] must be an array with [key, value]",
+            )));
+        }
+
+        let tuple = Array::from(&entry);
+        if tuple.length() < 2 {
+            return Err(JsString::from(&format!(
+                "SignerDefinition.tsaHeaders[{index}] must contain at least two elements",
+            )));
+        }
+
+        let key = tuple
+            .get(0)
+            .as_string()
+            .ok_or_else(|| JsString::from(&format!(
+                "SignerDefinition.tsaHeaders[{index}][0] must be a string",
+            )))?;
+
+        let value = tuple
+            .get(1)
+            .as_string()
+            .ok_or_else(|| JsString::from(&format!(
+                "SignerDefinition.tsaHeaders[{index}][1] must be a string",
+            )))?;
+
+        headers.push((key, value));
+    }
+
+    Ok(headers)
+}
+
+fn parse_optional_body(value: JsValue) -> Result<Option<Vec<u8>>, JsString> {
+    if value.is_undefined() || value.is_null() {
+        return Ok(None);
+    }
+
+    if let Some(body) = value.as_string() {
+        return Ok(Some(body.into_bytes()));
+    }
+
+    if value.is_instance_of::<Uint8Array>() {
+        let bytes: Uint8Array = value.unchecked_into();
+        return Ok(Some(bytes.to_vec()));
+    }
+
+    if value.is_instance_of::<ArrayBuffer>() {
+        let buffer: ArrayBuffer = value.unchecked_into();
+        let bytes = Uint8Array::new(&buffer);
+        return Ok(Some(bytes.to_vec()));
+    }
+
+    if ArrayBuffer::is_view(&value) {
+        let view = Uint8Array::new(&value);
+        return Ok(Some(view.to_vec()));
+    }
+
+    Err(JsString::from(
+        "SignerDefinition.tsaBody must be a string or ArrayBuffer",
+    ))
+}
+
+fn decode_cert_from_bytes(bytes: Vec<u8>, index: usize) -> Result<Vec<Vec<u8>>, JsString> {
+    match std::str::from_utf8(&bytes) {
+        Ok(text) => decode_pem_or_base64(text).map_err(|message| {
+            JsString::from(&format!(
+                "Failed to decode certificate at index {index}: {message}",
+            ))
+        }),
+        Err(_) => Ok(vec![bytes]),
+    }
+}
+
+fn decode_pem_or_base64(pem: &str) -> Result<Vec<Vec<u8>>, String> {
+    let trimmed = pem.trim();
+    if trimmed.is_empty() {
+        return Err("certificate string is empty".into());
+    }
+
+    if trimmed.starts_with("-----BEGIN") {
+        match pem::parse_many(trimmed) {
+            Ok(mut pems) if !pems.is_empty() => {
+                Ok(pems
+                    .drain(..)
+                    .map(|pem_entry| pem_entry.into_contents())
+                    .collect())
+            }
+            Ok(_) => Err("certificate string contained no PEM entries".into()),
+            Err(err) => Err(format!("failed to parse PEM certificate data: {err}")),
+        }
+    } else {
+        let sanitized: String = trimmed.chars().filter(|c| !c.is_whitespace()).collect();
+
+        if sanitized.is_empty() {
+            return Err("certificate string contained no base64 data".into());
+        }
+
+        base64::engine::general_purpose::STANDARD
+            .decode(sanitized.as_bytes())
+            .map(|bytes| vec![bytes])
+            .map_err(|err| format!("failed to decode base64 certificate data: {err}"))
     }
 }

--- a/packages/c2pa-wasm/src/wasm_signer.rs
+++ b/packages/c2pa-wasm/src/wasm_signer.rs
@@ -83,7 +83,15 @@ impl WasmSigner {
         let cert_chain = parse_cert_chain(certs_value)?;
 
         let direct_cose_value = Reflect::get(&js_value, &"directCoseHandling".into())?;
-        let direct_cose_handling = direct_cose_value.as_bool().unwrap_or(false);
+        let direct_cose_handling = match direct_cose_value.as_bool() {
+            Some(value) => value,
+            None if direct_cose_value.is_undefined() || direct_cose_value.is_null() => true,
+            None => {
+                return Err(JsError::new(
+                    "SignerDefinition.directCoseHandling must be a boolean",
+                ))
+            }
+        };
 
         let tsa_url_value = Reflect::get(&js_value, &"tsaUrl".into())?;
         let tsa_url = parse_optional_string(tsa_url_value)?;

--- a/packages/c2pa-wasm/src/wasm_signer.rs
+++ b/packages/c2pa-wasm/src/wasm_signer.rs
@@ -87,7 +87,7 @@ impl WasmSigner {
             Some(value) => value,
             None if direct_cose_value.is_undefined() || direct_cose_value.is_null() => true,
             None => {
-                return Err(JsError::new(
+                return Err(JsString::from(
                     "SignerDefinition.directCoseHandling must be a boolean",
                 ))
             }
@@ -203,7 +203,7 @@ fn parse_cert_chain(value: JsValue) -> Result<Vec<Vec<u8>>, JsString> {
 fn parse_cert_entry(value: JsValue, index: usize) -> Result<Vec<Vec<u8>>, JsString> {
     if let Some(pem) = value.as_string() {
         return decode_pem_or_base64(&pem).map_err(|message| {
-            JsString::from(&format!("Failed to decode certificate at index {index}: {message}"))
+            JsString::from(format!("Failed to decode certificate at index {index}: {message}"))
         });
     }
 
@@ -223,7 +223,7 @@ fn parse_cert_entry(value: JsValue, index: usize) -> Result<Vec<Vec<u8>>, JsStri
         return decode_cert_from_bytes(view.to_vec(), index);
     }
 
-    Err(JsString::from(&format!(
+    Err(JsString::from(format!(
         "Unsupported certificate value at index {index}; expected a PEM string or ArrayBuffer",
     )))
 }
@@ -255,14 +255,14 @@ fn parse_tsa_headers(value: JsValue) -> Result<Vec<(String, String)>, JsString> 
 
     for (index, entry) in headers_array.iter().enumerate() {
         if !Array::is_array(&entry) {
-            return Err(JsString::from(&format!(
+            return Err(JsString::from(format!(
                 "SignerDefinition.tsaHeaders[{index}] must be an array with [key, value]",
             )));
         }
 
         let tuple = Array::from(&entry);
         if tuple.length() < 2 {
-            return Err(JsString::from(&format!(
+            return Err(JsString::from(format!(
                 "SignerDefinition.tsaHeaders[{index}] must contain at least two elements",
             )));
         }
@@ -270,14 +270,14 @@ fn parse_tsa_headers(value: JsValue) -> Result<Vec<(String, String)>, JsString> 
         let key = tuple
             .get(0)
             .as_string()
-            .ok_or_else(|| JsString::from(&format!(
+            .ok_or_else(|| JsString::from(format!(
                 "SignerDefinition.tsaHeaders[{index}][0] must be a string",
             )))?;
 
         let value = tuple
             .get(1)
             .as_string()
-            .ok_or_else(|| JsString::from(&format!(
+            .ok_or_else(|| JsString::from(format!(
                 "SignerDefinition.tsaHeaders[{index}][1] must be a string",
             )))?;
 
@@ -320,7 +320,7 @@ fn parse_optional_body(value: JsValue) -> Result<Option<Vec<u8>>, JsString> {
 fn decode_cert_from_bytes(bytes: Vec<u8>, index: usize) -> Result<Vec<Vec<u8>>, JsString> {
     match std::str::from_utf8(&bytes) {
         Ok(text) => decode_pem_or_base64(text).map_err(|message| {
-            JsString::from(&format!(
+            JsString::from(format!(
                 "Failed to decode certificate at index {index}: {message}",
             ))
         }),

--- a/packages/c2pa-web/README.md
+++ b/packages/c2pa-web/README.md
@@ -61,6 +61,23 @@ const c2pa = await createC2pa();
 
 See also the [API reference documentation](https://contentauth.github.io/c2pa-js/modules/_contentauth_c2pa-web.html).
 
+### Configuring verification settings
+
+You can configure verification behavior globally when creating the SDK:
+
+```typescript
+const c2pa = await createC2pa({
+  wasmSrc,
+  settings: {
+    verify: {
+      verifyTrust: true,
+      verifyAfterReading: true,
+      verifyAfterSign: false
+    }
+  }
+});
+```
+
 ### Reading C2PA manifests
 
 Fetch an image and provide it to the `Reader`:

--- a/packages/c2pa-web/README.md
+++ b/packages/c2pa-web/README.md
@@ -78,6 +78,24 @@ const c2pa = await createC2pa({
 });
 ```
 
+### Configuring trust anchors and allowed EKUs
+
+To validate signing certificates against your own trust anchors and a custom list of allowed Extended Key Usage (EKU) OIDs:
+
+```typescript
+const c2pa = await createC2pa({
+  wasmSrc,
+  settings: {
+    trust: {
+      // PEM bundle of trusted root certificate(s).
+      trustAnchors: rootCertPem,
+      // Newline-delimited list of additional EKU OIDs that signing certificates may have.
+      trustConfig: additionalEkus
+    }
+  }
+});
+```
+
 ### Reading C2PA manifests
 
 Fetch an image and provide it to the `Reader`:

--- a/packages/c2pa-web/src/lib/settings.spec.ts
+++ b/packages/c2pa-web/src/lib/settings.spec.ts
@@ -21,6 +21,27 @@ describe('settings', () => {
           JSON.stringify({ builder: { generate_c2pa_archive: true } })
         );
       });
+
+      test('should pass through verify settings', async () => {
+        const settingsString = await settingsToWasmJson({
+          verify: {
+            verifyTrust: false,
+            verifyAfterReading: false,
+            verifyAfterSign: false
+          }
+        });
+
+        expect(settingsString).toEqual(
+          JSON.stringify({
+            builder: { generate_c2pa_archive: true },
+            verify: {
+              verify_trust: false,
+              verify_after_reading: false,
+              verify_after_sign: false
+            }
+          })
+        );
+      });
     });
 
     describe('trust', () => {

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -93,6 +93,10 @@ export interface VerifySettings {
    * Whether to verify the manifest after reading in the Reader. The default value is "true."
    */
   verifyAfterReading?: boolean;
+  /**
+   * Whether to verify the manifest after signing in the Builder.
+   */
+  verifyAfterSign?: boolean;
 }
 
 export interface BuilderSettings {

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -64,7 +64,9 @@ export interface TrustSettings {
    */
   trustAnchors?: string | string[];
   /**
-   * Trust store
+   * Additional Extended Key Usage (EKU) OIDs that signing certificates are allowed to have, in addition to the C2PA-required EKUs.
+   *
+   * Provided as a newline-delimited list of OID strings (the contents of a c2pa-rs trust `store.cfg` file).
    *
    * Possible values are: the text content of a .cfg file, a URL to fetch a .cfg file from, or an array of URLs that will be fetched and concatenated.
    */

--- a/packages/c2pa-web/src/lib/signer.ts
+++ b/packages/c2pa-web/src/lib/signer.ts
@@ -57,9 +57,9 @@ export async function getSerializablePayload(
   const certificates = signer.certs
     ? await signer.certs()
     : undefined;
-  const directCoseHandling = signer.directCoseHandling
+  const directCoseHandling = typeof signer.directCoseHandling === 'boolean'
     ? signer.directCoseHandling
-    : false;
+    : undefined;
   const tsaUrl = signer.timeAuthorityUrl
     ? signer.timeAuthorityUrl
     : undefined;

--- a/packages/c2pa-web/src/lib/signer.ts
+++ b/packages/c2pa-web/src/lib/signer.ts
@@ -16,6 +16,15 @@ export type SigningAlg =
   | 'ps512'
   | 'ed25519';
 
+export type SignerCertificate =
+  | string
+  | ArrayBuffer
+  | ArrayBufferView;
+
+export type SerializedSignerCertificate =
+  | string
+  | Uint8Array<ArrayBuffer>;
+
 export interface Signer {
   sign: (
     data: Uint8Array<ArrayBuffer>,
@@ -23,11 +32,21 @@ export interface Signer {
   ) => Promise<Uint8Array<ArrayBuffer>>;
   reserveSize: () => Promise<number>;
   alg: SigningAlg;
+  certs?: () => Promise<SignerCertificate[]>;
+  directCoseHandling?: boolean;
+  timeAuthorityUrl?: string;
+  timeAuthorityHeaders?: Array<[string, string]>;
+  timeAuthorityBody?: string | ArrayBuffer | ArrayBufferView;
 }
 
 export interface SerializableSigningPayload {
   reserveSize: number;
   alg: SigningAlg;
+  certs?: SerializedSignerCertificate[];
+  directCoseHandling?: boolean;
+  tsaUrl?: string;
+  tsaHeaders?: Array<[string, string]>;
+  tsaBody?: Uint8Array<ArrayBuffer> | string;
 }
 
 export async function getSerializablePayload(
@@ -35,9 +54,75 @@ export async function getSerializablePayload(
 ): Promise<SerializableSigningPayload> {
   const { alg } = signer;
   const reserveSize = await signer.reserveSize();
+  const certificates = signer.certs
+    ? await signer.certs()
+    : undefined;
+  const directCoseHandling = signer.directCoseHandling
+    ? signer.directCoseHandling
+    : false;
+  const tsaUrl = signer.timeAuthorityUrl
+    ? signer.timeAuthorityUrl
+    : undefined;
+  const tsaHeaders = signer.timeAuthorityHeaders
+    ? signer.timeAuthorityHeaders
+    : undefined;
+  const tsaBodyRaw = signer.timeAuthorityBody
+    ? signer.timeAuthorityBody
+    : undefined;
+
+  const normalizedCertificates = certificates?.map((certificate, index) => {
+    if (typeof certificate === 'string') {
+      return certificate;
+    }
+
+    if (certificate instanceof ArrayBuffer) {
+      return new Uint8Array(certificate.slice(0));
+    }
+
+    if (ArrayBuffer.isView(certificate)) {
+      const view = certificate as ArrayBufferView;
+      // Only accept ArrayBuffer, not SharedArrayBuffer
+      if (!(view.buffer instanceof ArrayBuffer)) {
+        throw new TypeError(
+          `Unsupported certificate buffer type at index ${index}. Only ArrayBuffer is supported.`
+        );
+      }
+      return new Uint8Array(
+        view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength)
+      );
+    }
+
+    throw new TypeError(
+      `Unsupported certificate type at index ${index}. Certificates must be provided as PEM strings or ArrayBuffer views.`
+    );
+  });
+
+  let normalizedTsaBody: Uint8Array<ArrayBuffer> | string | undefined;
+  if (tsaBodyRaw !== undefined) {
+    if (typeof tsaBodyRaw === 'string') {
+      normalizedTsaBody = tsaBodyRaw;
+    } else if (tsaBodyRaw instanceof ArrayBuffer) {
+      normalizedTsaBody = new Uint8Array(tsaBodyRaw.slice(0));
+    } else if (ArrayBuffer.isView(tsaBodyRaw)) {
+      const view = tsaBodyRaw as ArrayBufferView;
+      if (!(view.buffer instanceof ArrayBuffer)) {
+        throw new TypeError('Unsupported TSA body buffer type. Only ArrayBuffer is supported.');
+      }
+      normalizedTsaBody = new Uint8Array(
+        view.buffer.slice(view.byteOffset, view.byteOffset + view.byteLength)
+      );
+    } else {
+      throw new TypeError('Unsupported TSA body type. Expected string or ArrayBuffer view.');
+    }
+  }
 
   return {
     reserveSize,
-    alg
+    alg,
+    certs: normalizedCertificates,
+    directCoseHandling,
+    tsaUrl,
+    tsaHeaders,
+    tsaBody: normalizedTsaBody,
   };
 }

--- a/packages/c2pa-web/src/lib/worker.ts
+++ b/packages/c2pa-web/src/lib/worker.ts
@@ -131,19 +131,25 @@ rx(
     },
     async builder_sign(builderId, requestId, payload, format, blob) {
       const builder = builderMap.get(builderId);
-      const signedBytes = (await builder.sign(
-        {
-          reserveSize: payload.reserveSize,
-          alg: payload.alg,
-          sign: async (bytes) => {
-            const result = await tx.sign(
-              requestId,
-              transfer(bytes, bytes.buffer),
-              payload.reserveSize
-            );
-            return result;
-          }
+      const signerDefinition = {
+        reserveSize: payload.reserveSize,
+        alg: payload.alg,
+        certs: payload.certs,
+        directCoseHandling: payload.directCoseHandling,
+        tsaUrl: payload.tsaUrl,
+        tsaHeaders: payload.tsaHeaders,
+        tsaBody: payload.tsaBody,
+        sign: async (bytes: Uint8Array<ArrayBuffer>) => {
+          const result = await tx.sign(
+            requestId,
+            transfer(bytes, bytes.buffer),
+            payload.reserveSize
+          );
+          return result;
         },
+      } satisfies Parameters<typeof builder.sign>[0];
+      const signedBytes = (await builder.sign(
+        signerDefinition,
         format,
         blob
       )) as Uint8Array<ArrayBuffer>;
@@ -157,23 +163,28 @@ rx(
       blob
     ) {
       const builder = builderMap.get(builderId);
-      const { manifest, asset } = await builder.signAndGetManifestBytes(
-        {
-          reserveSize: payload.reserveSize,
-          alg: payload.alg,
-          sign: async (bytes) => {
-            const result = await tx.sign(
-              requestId,
-              transfer(bytes, bytes.buffer),
-              payload.reserveSize
-            );
-            return result;
-          }
+      const signerDefinition = {
+        reserveSize: payload.reserveSize,
+        alg: payload.alg,
+        certs: payload.certs,
+        directCoseHandling: payload.directCoseHandling,
+        tsaUrl: payload.tsaUrl,
+        tsaHeaders: payload.tsaHeaders,
+        tsaBody: payload.tsaBody,
+        sign: async (bytes: Uint8Array<ArrayBuffer>) => {
+          const result = await tx.sign(
+            requestId,
+            transfer(bytes, bytes.buffer),
+            payload.reserveSize
+          );
+          return result;
         },
+      } satisfies Parameters<typeof builder.signAndGetManifestBytes>[0];
+      const { manifest, asset } = await builder.signAndGetManifestBytes(
+        signerDefinition,
         format,
         blob
       );
-
       return transfer(
         {
           manifest,

--- a/packages/c2pa-web/src/lib/worker.ts
+++ b/packages/c2pa-web/src/lib/worker.ts
@@ -135,19 +135,25 @@ rx(
     },
     async builder_sign(builderId, requestId, payload, format, blob) {
       const builder = builderMap.get(builderId);
-      const signedBytes = (await builder.sign(
-        {
-          reserveSize: payload.reserveSize,
-          alg: payload.alg,
-          sign: async (bytes) => {
-            const result = await tx.sign(
-              requestId,
-              transfer(bytes, bytes.buffer),
-              payload.reserveSize
-            );
-            return result;
-          }
+      const signerDefinition = {
+        reserveSize: payload.reserveSize,
+        alg: payload.alg,
+        certs: payload.certs,
+        directCoseHandling: payload.directCoseHandling,
+        tsaUrl: payload.tsaUrl,
+        tsaHeaders: payload.tsaHeaders,
+        tsaBody: payload.tsaBody,
+        sign: async (bytes: Uint8Array<ArrayBuffer>) => {
+          const result = await tx.sign(
+            requestId,
+            transfer(bytes, bytes.buffer),
+            payload.reserveSize
+          );
+          return result;
         },
+      } satisfies Parameters<typeof builder.sign>[0];
+      const signedBytes = (await builder.sign(
+        signerDefinition,
         format,
         blob
       )) as Uint8Array<ArrayBuffer>;
@@ -161,23 +167,28 @@ rx(
       blob
     ) {
       const builder = builderMap.get(builderId);
-      const { manifest, asset } = await builder.signAndGetManifestBytes(
-        {
-          reserveSize: payload.reserveSize,
-          alg: payload.alg,
-          sign: async (bytes) => {
-            const result = await tx.sign(
-              requestId,
-              transfer(bytes, bytes.buffer),
-              payload.reserveSize
-            );
-            return result;
-          }
+      const signerDefinition = {
+        reserveSize: payload.reserveSize,
+        alg: payload.alg,
+        certs: payload.certs,
+        directCoseHandling: payload.directCoseHandling,
+        tsaUrl: payload.tsaUrl,
+        tsaHeaders: payload.tsaHeaders,
+        tsaBody: payload.tsaBody,
+        sign: async (bytes: Uint8Array<ArrayBuffer>) => {
+          const result = await tx.sign(
+            requestId,
+            transfer(bytes, bytes.buffer),
+            payload.reserveSize
+          );
+          return result;
         },
+      } satisfies Parameters<typeof builder.signAndGetManifestBytes>[0];
+      const { manifest, asset } = await builder.signAndGetManifestBytes(
+        signerDefinition,
         format,
         blob
       );
-
       return transfer(
         {
           manifest,


### PR DESCRIPTION
When trying to use the `Builder` to embed a signed manifest in a media file, we encountered a few gaps:

* `direct_cose_handling` was always set to `true`
* There was no way to pass certificates down to the signing process
* There were a few more options missing on `Signer`

Using the Node.js implementation as guidance, I made those changes and confirmed it was working in our sign and embedding flow.