### PR TITLE
feat: Ingredient API to save snapshot and rehydrate later

### DIFF
--- a/.changeset/rich-grapes-clean.md
+++ b/.changeset/rich-grapes-clean.md
@@ -1,0 +1,6 @@
+---
+'@contentauth/c2pa-wasm': minor
+'@contentauth/c2pa-web': minor
+---
+
+Add an ingredient builder API and ability to snapshot ingredients and restore later

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,6 +390,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
+ "serde_json",
  "thiserror 2.0.17",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/packages/c2pa-wasm/Cargo.toml
+++ b/packages/c2pa-wasm/Cargo.toml
@@ -25,6 +25,7 @@ async-trait = "0.1.88"
 thiserror = "2.0.12"
 serde-wasm-bindgen = "0.6.5"
 serde = "1.0.219"
+serde_json = "1.0.140"
 serde_bytes = "0.11.19"
 
 [dependencies.web-sys]

--- a/packages/c2pa-wasm/src/error.rs
+++ b/packages/c2pa-wasm/src/error.rs
@@ -27,6 +27,12 @@ impl WasmError {
     }
 }
 
+impl From<serde_json::Error> for WasmError {
+    fn from(value: serde_json::Error) -> Self {
+        WasmError::other(value)
+    }
+}
+
 impl From<WasmError> for JsError {
     fn from(value: WasmError) -> Self {
         JsError::new(&format!("{:?}", value))

--- a/packages/c2pa-wasm/src/lib.rs
+++ b/packages/c2pa-wasm/src/lib.rs
@@ -22,6 +22,9 @@ pub mod wasm_reader;
 /// Exposes a builder API to JS via wasm-bindgen.
 pub mod wasm_builder;
 
+/// Exposes an ingredient API to JS via wasm-bindgen.
+pub mod wasm_ingredient;
+
 /// Exposes a JS Callback signer API to JS via wasm-bindgen.
 pub mod wasm_signer;
 

--- a/packages/c2pa-wasm/src/wasm_ingredient.rs
+++ b/packages/c2pa-wasm/src/wasm_ingredient.rs
@@ -1,0 +1,75 @@
+// Copyright 2025 Adobe
+// All Rights Reserved.
+//
+// NOTICE: Adobe permits you to use, modify, and distribute this file in
+// accordance with the terms of the Adobe license agreement accompanying
+// it.
+
+use c2pa::Ingredient;
+use js_sys::{Error as JsError, JsString, Uint8Array};
+use wasm_bindgen::prelude::*;
+
+use crate::error::WasmError;
+
+/// Wraps a `c2pa::Ingredient`.
+#[wasm_bindgen]
+pub struct WasmIngredient {
+    ingredient: Ingredient,
+}
+
+#[wasm_bindgen]
+impl WasmIngredient {
+    /// Attempts to create a new `WasmIngredient` from an asset's format and raw bytes.
+    #[wasm_bindgen(js_name = fromMemory)]
+    pub fn from_memory(format: &str, buffer: &Uint8Array) -> Result<WasmIngredient, JsError> {
+        let bytes = buffer.to_vec();
+        let ingredient = Ingredient::from_memory(format, &bytes).map_err(WasmError::from)?;
+
+        Ok(WasmIngredient { ingredient })
+    }
+
+    /// Attempts to create a new `WasmIngredient` from ingredient JSON and optional
+    /// manifest store bytes.
+    ///
+    /// This supports an "ingredient rehydration" workflow where the original ingredient asset
+    /// bytes are not available.
+    #[wasm_bindgen(js_name = fromJsonAndManifestStore)]
+    pub fn from_json_and_manifest_store(
+        ingredient_json: &str,
+        manifest_data: Option<Uint8Array>,
+    ) -> Result<WasmIngredient, JsError> {
+        let mut ingredient = Ingredient::from_json(ingredient_json).map_err(WasmError::from)?;
+
+        if let Some(manifest_data) = manifest_data {
+            let data_vec = manifest_data.to_vec();
+            if !data_vec.is_empty() {
+                ingredient
+                    .set_manifest_data(data_vec)
+                    .map_err(WasmError::from)?;
+            }
+        }
+
+        Ok(WasmIngredient { ingredient })
+    }
+
+    /// Returns a serde JSON representation of this ingredient.
+    #[wasm_bindgen(js_name = toJson)]
+    pub fn to_json(&self) -> Result<JsString, JsError> {
+        let json = serde_json::to_string(&self.ingredient).map_err(WasmError::from)?;
+        Ok(JsString::from(json))
+    }
+
+    /// Returns the embedded manifest store bytes (JUMBF / application/c2pa) if present.
+    ///
+    /// This mirrors `Ingredient::manifest_data()`.
+    #[wasm_bindgen(js_name = manifestStoreBytes)]
+    pub fn manifest_store_bytes(&self) -> Result<JsValue, JsError> {
+        match self.ingredient.manifest_data() {
+            Some(cow) => {
+                let bytes = cow.into_owned();
+                Ok(Uint8Array::from(bytes.as_slice()).into())
+            }
+            None => Ok(JsValue::NULL),
+        }
+    }
+}

--- a/packages/c2pa-web/src/common.ts
+++ b/packages/c2pa-web/src/common.ts
@@ -19,6 +19,12 @@ export type {
 
 export type { Signer, SigningAlg } from './lib/signer.js';
 
+export type {
+  IngredientFactory,
+  IngredientRef,
+  IngredientSnapshot,
+} from './lib/ingredient.js';
+
 export {
   isSupportedReaderFormat,
   READER_SUPPORTED_FORMATS,

--- a/packages/c2pa-web/src/lib/c2pa.ts
+++ b/packages/c2pa-web/src/lib/c2pa.ts
@@ -11,6 +11,7 @@ import { createReaderFactory, ReaderFactory } from './reader.js';
 import { WASM_SRI } from '@contentauth/c2pa-wasm';
 import { Settings, settingsToWasmJson } from './settings.js';
 import { BuilderFactory, createBuilderFactory } from './builder.js';
+import { createIngredientFactory, IngredientFactory } from './ingredient.js';
 
 export interface Config {
   /**
@@ -36,6 +37,11 @@ export interface C2paSdk {
   builder: BuilderFactory;
 
   /**
+   * Contains methods for creating Ingredient objects.
+   */
+  ingredient: IngredientFactory;
+
+  /**
    * Terminates the SDK's underlying web worker.
    */
   dispose: () => void;
@@ -55,6 +61,7 @@ export async function createC2pa(config: Config): Promise<C2paSdk> {
   return {
     reader: createReaderFactory(worker),
     builder: createBuilderFactory(worker),
+    ingredient: createIngredientFactory(worker),
     dispose: worker.terminate,
   };
 }

--- a/packages/c2pa-web/src/lib/ingredient.spec.ts
+++ b/packages/c2pa-web/src/lib/ingredient.spec.ts
@@ -1,0 +1,127 @@
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+
+import { test, describe, expect } from 'test/methods.js';
+import { getBlobForAsset } from 'test/utils.js';
+
+import C_with_CAWG_data from 'test/assets/C_with_CAWG_data.jpg';
+import C_with_CAWG_data_thumbnail from 'test/assets/C_with_CAWG_data_thumbnail.jpg';
+
+describe('ingredient', () => {
+  test('should omit manifestStoreBytes when not present on the source asset', async ({
+    c2pa,
+  }) => {
+    const blob = await getBlobForAsset(C_with_CAWG_data_thumbnail);
+
+    const ingredientRef = await c2pa.ingredient.fromBlob(blob.type, blob);
+    const snapshot = await ingredientRef.toSnapshot();
+
+    expect(snapshot.ingredient).toBeTruthy();
+    expect(snapshot.manifestStoreBytes).toBeUndefined();
+
+    const rehydratedIngredientRef = await c2pa.ingredient.fromSnapshot(
+      snapshot
+    );
+    const snapshotFromRehydrated = await rehydratedIngredientRef.toSnapshot();
+
+    expect(snapshotFromRehydrated.ingredient).toEqual(snapshot.ingredient);
+    expect(snapshotFromRehydrated.manifestStoreBytes).toBeUndefined();
+
+    await ingredientRef.free();
+    await rehydratedIngredientRef.free();
+  });
+
+  test('should snapshot and rehydrate an ingredient (with manifest store bytes)', async ({
+    c2pa,
+  }) => {
+    const blob = await getBlobForAsset(C_with_CAWG_data);
+
+    const ingredientRef = await c2pa.ingredient.fromBlob(blob.type, blob);
+
+    const snapshot = await ingredientRef.toSnapshot();
+
+    expect(snapshot.ingredient).toBeTruthy();
+    expect(snapshot.manifestStoreBytes).toBeInstanceOf(Uint8Array);
+    expect(snapshot.manifestStoreBytes!.byteLength).toBeGreaterThan(0);
+
+    const rehydratedIngredientRef = await c2pa.ingredient.fromSnapshot(
+      snapshot
+    );
+    const snapshotFromRehydrated = await rehydratedIngredientRef.toSnapshot();
+
+    expect(snapshotFromRehydrated.ingredient).toEqual(snapshot.ingredient);
+    expect(snapshotFromRehydrated.manifestStoreBytes).toEqual(
+      snapshot.manifestStoreBytes
+    );
+
+    await ingredientRef.free();
+    await rehydratedIngredientRef.free();
+  });
+
+  test('builder.addIngredientFromRef should accept an IngredientRef and relationship', async ({
+    c2pa,
+  }) => {
+    const blob = await getBlobForAsset(C_with_CAWG_data);
+
+    const ingredientRef = await c2pa.ingredient.fromBlob(blob.type, blob);
+
+    const builder = await c2pa.builder.new();
+    await builder.addIngredientFromRef(ingredientRef, 'componentOf');
+
+    const definition = await builder.getDefinition();
+
+    expect(definition.ingredients).toBeDefined();
+    expect(definition.ingredients!).toHaveLength(1);
+    expect(definition.ingredients![0]).toHaveProperty(
+      'relationship',
+      'componentOf'
+    );
+
+    await ingredientRef.free();
+    await builder.free();
+  });
+
+  test('builder.addIngredientFromRef should work with a rehydrated IngredientRef', async ({
+    c2pa,
+  }) => {
+    const blob = await getBlobForAsset(C_with_CAWG_data);
+
+    const ingredientRef = await c2pa.ingredient.fromBlob(blob.type, blob);
+    const snapshot = await ingredientRef.toSnapshot();
+    const rehydratedIngredientRef = await c2pa.ingredient.fromSnapshot(
+      snapshot
+    );
+
+    const builder = await c2pa.builder.new();
+    await builder.addIngredientFromRef(rehydratedIngredientRef, 'componentOf');
+
+    const definition = await builder.getDefinition();
+
+    expect(definition.ingredients).toBeDefined();
+    expect(definition.ingredients!).toHaveLength(1);
+    expect(definition.ingredients![0]).toHaveProperty(
+      'relationship',
+      'componentOf'
+    );
+
+    await ingredientRef.free();
+    await rehydratedIngredientRef.free();
+    await builder.free();
+  });
+
+  test('should be freeable', async ({ c2pa }) => {
+    const blob = await getBlobForAsset(C_with_CAWG_data);
+
+    const ingredientRef = await c2pa.ingredient.fromBlob(blob.type, blob);
+
+    await ingredientRef.free();
+
+    await expect(ingredientRef.toSnapshot()).rejects.toThrowError();
+  });
+});

--- a/packages/c2pa-web/src/lib/ingredient.ts
+++ b/packages/c2pa-web/src/lib/ingredient.ts
@@ -1,0 +1,125 @@
+/**
+ * Copyright 2025 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+
+import type { Ingredient as IngredientDefinition } from '@contentauth/c2pa-types';
+
+import type { WorkerManager } from './worker/workerManager.js';
+
+/**
+ * Factory for creating {@link IngredientRef} objects from assets or snapshots.
+ */
+export interface IngredientFactory {
+  /**
+   * Create an Ingredient from an asset file.
+   *
+   * @param format MIME type of the asset (e.g., 'image/jpeg').
+   * @param blob The asset's bytes.
+   */
+  fromBlob: (format: string, blob: Blob) => Promise<IngredientRef>;
+
+  /**
+   * Rehydrate an Ingredient from a previously saved snapshot.
+   *
+   * @param snapshot A snapshot previously obtained from {@link IngredientRef.toSnapshot}.
+   */
+  fromSnapshot: (snapshot: IngredientSnapshot) => Promise<IngredientRef>;
+}
+
+/**
+ * A serializable representation of an ingredient that can be persisted and later
+ * restored via {@link IngredientFactory.fromSnapshot}.
+ */
+export interface IngredientSnapshot {
+  /** The ingredient metadata. */
+  ingredient: IngredientDefinition;
+  /** The embedded C2PA manifest store bytes (JUMBF), if present on the source asset. */
+  manifestStoreBytes?: Uint8Array;
+}
+
+/**
+ * A handle to an ingredient in WASM memory. Must be freed when no longer needed.
+ */
+export interface IngredientRef {
+  /**
+   * Serialize this ingredient into a snapshot suitable for persistence.
+   *
+   * `manifestStoreBytes` will be omitted if no embedded manifest store exists on the source asset.
+   */
+  toSnapshot: () => Promise<IngredientSnapshot>;
+
+  /**
+   * Dispose of this Ingredient, freeing the memory it occupied and preventing further use.
+   */
+  free: () => Promise<void>;
+}
+
+export function createIngredientFactory(
+  worker: WorkerManager
+): IngredientFactory {
+  const { tx } = worker;
+
+  const registry = new FinalizationRegistry<number>((id) => {
+    tx.ingredient_free(id);
+  });
+
+  return {
+    async fromBlob(format: string, blob: Blob) {
+      const ingredientId = await tx.ingredient_fromBlob(format, blob);
+
+      const ingredient = createIngredient(worker, ingredientId, () => {
+        registry.unregister(ingredient);
+      });
+      registry.register(ingredient, ingredientId, ingredient);
+
+      return ingredient;
+    },
+
+    async fromSnapshot(snapshot: IngredientSnapshot) {
+      const ingredientJson = JSON.stringify(snapshot.ingredient);
+      const ingredientId = await tx.ingredient_fromJsonAndManifestStore(
+        ingredientJson,
+        snapshot.manifestStoreBytes
+      );
+
+      const ingredient = createIngredient(worker, ingredientId, () => {
+        registry.unregister(ingredient);
+      });
+      registry.register(ingredient, ingredientId, ingredient);
+
+      return ingredient;
+    },
+  };
+}
+
+function createIngredient(
+  worker: WorkerManager,
+  id: number,
+  onFree: () => void
+): IngredientRef {
+  const { tx } = worker;
+
+  return {
+    async toSnapshot(): Promise<IngredientSnapshot> {
+      const json = await tx.ingredient_toJson(id);
+      const ingredient = JSON.parse(json) as IngredientDefinition;
+
+      const manifestStoreBytes = await tx.ingredient_manifestStoreBytes(id);
+
+      return {
+        ingredient,
+        manifestStoreBytes: manifestStoreBytes ?? undefined,
+      };
+    },
+
+    async free(): Promise<void> {
+      onFree();
+      await tx.ingredient_free(id);
+    },
+  };
+}

--- a/packages/c2pa-web/src/lib/worker/rpc.ts
+++ b/packages/c2pa-web/src/lib/worker/rpc.ts
@@ -42,6 +42,20 @@ const { createTx, rx } = channel<{
   builder_fromJson: (json: string, contextJson?: string) => number;
   builder_fromArchive: (archive: Blob, contextJson?: string) => number;
 
+  // Ingredient construction methods
+  ingredient_fromBlob: (format: string, blob: Blob) => Promise<number>;
+  ingredient_fromJsonAndManifestStore: (
+    ingredientJson: string,
+    manifestData?: Uint8Array
+  ) => number;
+
+  // Ingredient methods
+  ingredient_toJson: (ingredientId: number) => string;
+  ingredient_manifestStoreBytes: (
+    ingredientId: number
+  ) => Uint8Array<ArrayBuffer> | null;
+  ingredient_free: (ingredientId: number) => void;
+
   // Builder methods
   builder_setIntent: (builderId: number, intent: BuilderIntent) => void;
   builder_addAction: (builderId: number, action: Action) => void;
@@ -62,6 +76,12 @@ const { createTx, rx } = channel<{
     format: string,
     blob: Blob
   ) => void;
+  builder_addIngredientFromJsonAndManifestStore(
+    builderId: number,
+    ingredientJson: string,
+    manifestData?: Uint8Array,
+    relationship?: string
+  ): void;
   builder_addResourceFromBlob: (
     builderId: number,
     id: string,


### PR DESCRIPTION
This exposes functionality from the Rust SDK to create an ingredient from a file, serialize it to a snapshot for persistence, and later restore it without needing the original asset bytes.

This enables workflows where ingredients need to be cached and restored later for signing.

Usage:

```ts
// Create & persist ingredient
const ref = await c2pa.ingredient.fromBlob(format, blob);
const snapshot = await ref.toSnapshot();
await save(snapshot); // save the snapshot somewhere

// Restore & use
const snapshot = load(); // load the snapshot from somewhere
const ref = await c2pa.ingredient.fromSnapshot(snapshot);
await builder.addIngredientFromRef(ref, 'componentOf');
```

Closes #70