### PR TITLE
build: remove unused type export and update config to fail builds on type errors

### DIFF
--- a/.changeset/brave-roses-obey.md
+++ b/.changeset/brave-roses-obey.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-web': patch
+---
+
+Removed an export of a non-existent type.

--- a/packages/c2pa-web/src/common.ts
+++ b/packages/c2pa-web/src/common.ts
@@ -29,7 +29,6 @@ export type {
   VerifySettings,
   TrustSettings,
   BuilderSettings,
-  BuilderThumbnailSettings,
   CawgTrustSettings
 } from './lib/settings.js';
 

--- a/packages/c2pa-web/vite.config.ts
+++ b/packages/c2pa-web/vite.config.ts
@@ -25,11 +25,6 @@ export default defineConfig(() => ({
       afterDiagnostic(diagnostics) {
         const errors = diagnostics.filter(d => d.category === ts.DiagnosticCategory.Error);
         if (errors.length > 0) {
-          console.error(ts.formatDiagnosticsWithColorAndContext(errors, {
-            getCurrentDirectory: () => process.cwd(),
-            getCanonicalFileName: f => f,
-            getNewLine: () => '\n',
-          }));
           throw new Error(`vite-plugin-dts: Found ${errors.length} type error(s).`);
         }
       }

--- a/packages/c2pa-web/vite.config.ts
+++ b/packages/c2pa-web/vite.config.ts
@@ -13,6 +13,7 @@ import { workspaceRoot } from '@nx/devkit';
 import { rimrafSync } from 'rimraf';
 import { join } from 'path';
 import { mkdirSync, linkSync } from 'fs';
+import ts from 'typescript';
 
 export default defineConfig(() => ({
   root: __dirname,
@@ -20,7 +21,18 @@ export default defineConfig(() => ({
   plugins: [
     dts({
       entryRoot: 'src',
-      tsconfigPath: join(__dirname, 'tsconfig.lib.json')
+      tsconfigPath: join(__dirname, 'tsconfig.lib.json'),
+      afterDiagnostic(diagnostics) {
+        const errors = diagnostics.filter(d => d.category === ts.DiagnosticCategory.Error);
+        if (errors.length > 0) {
+          console.error(ts.formatDiagnosticsWithColorAndContext(errors, {
+            getCurrentDirectory: () => process.cwd(),
+            getCanonicalFileName: f => f,
+            getNewLine: () => '\n',
+          }));
+          throw new Error(`vite-plugin-dts: Found ${errors.length} type error(s).`);
+        }
+      }
     }),
     tsconfigPaths(),
     createBuildPlugin()


### PR DESCRIPTION
This PR:

- Removes a type export that was missed in a previous PR, since that type no longer exists
- Updates the Vite config to fail the build when it encounters a type error (such as trying to export a type that no longer exists)