### PR TITLE
fix: broken error handling in Firefox

### DIFF
--- a/.changeset/afraid-lands-shave.md
+++ b/.changeset/afraid-lands-shave.md
@@ -1,0 +1,6 @@
+---
+'@contentauth/c2pa-wasm': patch
+'@contentauth/c2pa-web': patch
+---
+
+Fix broken error handling in Firefox that could cause indefinite hangs

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,3 +1,4 @@
 {
-  "singleQuote": true
+  "singleQuote": true,
+  "trailingComma": "none"
 }

--- a/packages/c2pa-wasm/src/error.rs
+++ b/packages/c2pa-wasm/src/error.rs
@@ -7,7 +7,7 @@
 
 use std::error::Error;
 
-use js_sys::Error as JsError;
+use js_sys::{Error as JsError, JsString};
 
 #[derive(thiserror::Error, Debug)]
 pub enum WasmError {
@@ -30,5 +30,11 @@ impl WasmError {
 impl From<WasmError> for JsError {
     fn from(value: WasmError) -> Self {
         JsError::new(&format!("{value:?}"))
+    }
+}
+
+impl From<WasmError> for JsString {
+    fn from(value: WasmError) -> Self {
+        format!("{value:?}").into()
     }
 }

--- a/packages/c2pa-wasm/src/settings.rs
+++ b/packages/c2pa-wasm/src/settings.rs
@@ -5,12 +5,21 @@
 // accordance with the terms of the Adobe license agreement accompanying
 // it.
 
-use crate::error::WasmError;
+use js_sys::JsString;
 use wasm_bindgen::prelude::*;
+
+use crate::error::WasmError;
+
+/**
+ * NOTE: we can only return Err(JsString) or Err(JsValue) as error types here, because for some as-of-yet unknown
+ * reason, wasm-bindgen appears to mishandle JsErrors when created in a Firefox web worker.
+ *
+ * See: https://github.com/wasm-bindgen/wasm-bindgen/issues/4961
+ */
 
 /// Accepts a JSON-serialized string to be loaded as c2pa-rs settings.
 #[wasm_bindgen(js_name = loadSettings)]
-pub fn load_settings(settings: &str) -> Result<(), js_sys::Error> {
+pub fn load_settings(settings: &str) -> Result<(), JsString> {
     c2pa::settings::Settings::from_string(settings, "json").map_err(WasmError::other)?;
 
     Ok(())

--- a/packages/c2pa-wasm/src/stream/blob_stream.rs
+++ b/packages/c2pa-wasm/src/stream/blob_stream.rs
@@ -54,11 +54,7 @@ fn get_vec_u8_from_blob(blob: &Blob, offset: usize, len: usize) -> IoResult<Vec<
     let slice_u8array = reader_sync
         .read_as_array_buffer(&slice)
         .map(|array_buffer| Uint8Array::new(&array_buffer))
-        .map_err(|err| {
-            IoError::other(
-                format!("Failed to read blob slice. Details: {err:?}"),
-            )
-        })?;
+        .map_err(|err| IoError::other(format!("Failed to read blob slice. Details: {err:?}")))?;
 
     let mut buf = vec![0; slice_u8array.byte_length() as usize];
     slice_u8array.copy_to(&mut buf);

--- a/packages/c2pa-wasm/src/utils.rs
+++ b/packages/c2pa-wasm/src/utils.rs
@@ -7,11 +7,11 @@
 
 use std::io::Cursor;
 
-use js_sys::{Error as JsError, Uint8Array};
+use js_sys::Uint8Array;
 
 use crate::error::WasmError;
 
-pub fn cursor_to_u8array(cursor: Cursor<Vec<u8>>) -> Result<Uint8Array, JsError> {
+pub fn cursor_to_u8array(cursor: Cursor<Vec<u8>>) -> Result<Uint8Array, WasmError> {
     let data = cursor.into_inner();
     let data_len: u32 = data.len().try_into().map_err(WasmError::other)?;
     let uint8array = Uint8Array::new_with_length(data_len);

--- a/packages/c2pa-wasm/src/wasm_builder.rs
+++ b/packages/c2pa-wasm/src/wasm_builder.rs
@@ -7,8 +7,8 @@
 
 use std::io::Cursor;
 
-use c2pa::{assertions::Action, Builder, BuilderIntent, Context, Ingredient};
-use js_sys::{Error as JsError, JsString, Uint8Array};
+use c2pa::{Builder, BuilderIntent, Context, Ingredient, assertions::Action};
+use js_sys::{JsString, Uint8Array};
 use serde::{Deserialize, Serialize};
 use serde_wasm_bindgen::Serializer;
 use wasm_bindgen::prelude::*;
@@ -37,12 +37,19 @@ struct AssetAndManifestBytes {
     pub manifest: Vec<u8>,
 }
 
+/**
+ * NOTE: we can only return Err(JsString) or Err(JsValue) as error types here, because for some as-of-yet unknown
+ * reason, wasm-bindgen appears to mishandle JsErrors when created in a Firefox web worker.
+ *
+ * See: https://github.com/wasm-bindgen/wasm-bindgen/issues/4961
+ */
+
 #[wasm_bindgen]
 impl WasmBuilder {
     /// Creates a new `WasmBuilder` with a minimal manifest definition.
     /// Optionally accepts a context JSON string to configure the builder.
     #[wasm_bindgen(js_name = new)]
-    pub fn new(context_json: Option<String>) -> Result<WasmBuilder, JsError> {
+    pub fn new(context_json: Option<String>) -> Result<WasmBuilder, JsString> {
         let builder = if let Some(json) = context_json {
             let context = Context::new()
                 .with_settings(json.as_str())
@@ -57,7 +64,7 @@ impl WasmBuilder {
 
     /// Sets the builder "intent."
     #[wasm_bindgen(js_name = setIntent)]
-    pub fn set_intent(&mut self, json_intent: JsValue) -> Result<(), JsError> {
+    pub fn set_intent(&mut self, json_intent: JsValue) -> Result<(), JsString> {
         let intent: BuilderIntent =
             serde_wasm_bindgen::from_value(json_intent).map_err(WasmError::from)?;
         self.builder.set_intent(intent);
@@ -68,7 +75,7 @@ impl WasmBuilder {
     /// Attempts to create a new `WasmBuilder` from a JSON ManifestDefinition string.
     /// Optionally accepts a context JSON string to configure the builder.
     #[wasm_bindgen(js_name = fromJson)]
-    pub fn from_json(json: &str, context_json: Option<String>) -> Result<WasmBuilder, JsError> {
+    pub fn from_json(json: &str, context_json: Option<String>) -> Result<WasmBuilder, JsString> {
         let builder = if let Some(ctx_json) = context_json {
             let context = Context::new()
                 .with_settings(ctx_json.as_str())
@@ -93,7 +100,7 @@ impl WasmBuilder {
     pub fn from_archive(
         archive: &Blob,
         context_json: Option<String>,
-    ) -> Result<WasmBuilder, JsError> {
+    ) -> Result<WasmBuilder, JsString> {
         let stream = BlobStream::new(archive);
         let builder = if let Some(ctx_json) = context_json {
             let context = Context::new()
@@ -120,7 +127,7 @@ impl WasmBuilder {
 
     /// Add an action to the manifest's `Actions` assertion.
     #[wasm_bindgen(js_name = addAction)]
-    pub fn add_action(&mut self, action: JsValue) -> Result<(), JsError> {
+    pub fn add_action(&mut self, action: JsValue) -> Result<(), JsString> {
         let action: Action = serde_wasm_bindgen::from_value(action).map_err(WasmError::from)?;
 
         self.builder.add_action(action).map_err(WasmError::from)?;
@@ -145,7 +152,7 @@ impl WasmBuilder {
 
     /// Sets a thumbnail from a [`Blob`] to be included in the manifest. The thumbnail should represent the asset being signed.
     #[wasm_bindgen(js_name = setThumbnailFromBlob)]
-    pub fn set_thumbnail_from_blob(&mut self, format: &str, blob: &Blob) -> Result<(), JsError> {
+    pub fn set_thumbnail_from_blob(&mut self, format: &str, blob: &Blob) -> Result<(), JsString> {
         let mut stream = BlobStream::new(blob);
         self.builder
             .set_thumbnail(format, &mut stream)
@@ -159,7 +166,7 @@ impl WasmBuilder {
     /// # Arguments
     /// * `ingredient_json` - A JSON string representing the ingredient.
     #[wasm_bindgen(js_name = addIngredient)]
-    pub fn add_ingredient(&mut self, json: &str) -> Result<(), JsError> {
+    pub fn add_ingredient(&mut self, json: &str) -> Result<(), JsString> {
         let ingredient = Ingredient::from_json(json).map_err(WasmError::from)?;
         self.builder.add_ingredient(ingredient);
 
@@ -178,7 +185,7 @@ impl WasmBuilder {
         json: &str,
         format: &str,
         blob: &Blob,
-    ) -> Result<(), JsError> {
+    ) -> Result<(), JsString> {
         let mut stream = BlobStream::new(blob);
         self.builder
             .add_ingredient_from_stream(json, format, &mut stream)
@@ -189,7 +196,7 @@ impl WasmBuilder {
 
     /// Add a [`Blob`] to the manifest as a resource. The ID must match an identifier in the manifest.
     #[wasm_bindgen(js_name = addResourceFromBlob)]
-    pub fn add_resource_from_blob(&mut self, id: &str, blob: &Blob) -> Result<(), JsError> {
+    pub fn add_resource_from_blob(&mut self, id: &str, blob: &Blob) -> Result<(), JsString> {
         let mut stream = BlobStream::new(blob);
         self.builder
             .add_resource(id, &mut stream)
@@ -200,7 +207,7 @@ impl WasmBuilder {
 
     /// Get the current manifest definition.
     #[wasm_bindgen(js_name = getDefinition)]
-    pub fn get_definition(&self) -> Result<JsString, JsError> {
+    pub fn get_definition(&self) -> Result<JsString, JsString> {
         let manifest_definition: JsString = self
             .builder
             .definition
@@ -213,7 +220,7 @@ impl WasmBuilder {
 
     /// "Save" a builder to an archive.
     #[wasm_bindgen(js_name = toArchive)]
-    pub fn to_archive(&mut self) -> Result<Uint8Array, JsError> {
+    pub fn to_archive(&mut self) -> Result<Uint8Array, JsString> {
         let data = Vec::new();
         let mut stream = Cursor::new(data);
 
@@ -221,7 +228,7 @@ impl WasmBuilder {
             .to_archive(&mut stream)
             .map_err(WasmError::from)?;
 
-        cursor_to_u8array(stream)
+        Ok(cursor_to_u8array(stream)?)
     }
 
     /// Sign an asset using the provided SignerDefinition, format, and source Blob.
@@ -231,7 +238,7 @@ impl WasmBuilder {
         signer_definition: &SignerDefinition,
         format: &str,
         source: &Blob,
-    ) -> Result<Vec<u8>, JsError> {
+    ) -> Result<Vec<u8>, JsString> {
         let mut asset: Vec<u8> = Vec::new();
 
         self.sign_internal(signer_definition, format, source, &mut asset)
@@ -248,7 +255,7 @@ impl WasmBuilder {
         signer_definition: &SignerDefinition,
         format: &str,
         source: &Blob,
-    ) -> Result<JsValue, JsError> {
+    ) -> Result<JsValue, JsString> {
         let mut asset: Vec<u8> = Vec::new();
 
         let manifest = self
@@ -268,7 +275,7 @@ impl WasmBuilder {
         format: &str,
         source: &Blob,
         dest: &mut Vec<u8>,
-    ) -> Result<Vec<u8>, JsError> {
+    ) -> Result<Vec<u8>, JsString> {
         let signer = WasmSigner::from_definition(signer_definition)?;
         let mut stream = BlobStream::new(source);
 

--- a/packages/c2pa-wasm/src/wasm_reader.rs
+++ b/packages/c2pa-wasm/src/wasm_reader.rs
@@ -8,7 +8,7 @@
 use std::io::{Cursor, Read, Seek};
 
 use c2pa::{Context, Reader};
-use js_sys::{Error as JsError, Uint8Array};
+use js_sys::{JsString, Uint8Array};
 use serde::Serialize;
 use serde_wasm_bindgen::Serializer;
 use wasm_bindgen::prelude::*;
@@ -23,6 +23,13 @@ pub struct WasmReader {
     serializer: Serializer,
 }
 
+/**
+ * NOTE: we can only return Err(JsString) or Err(JsValue) as error types here, because for some as-of-yet unknown
+ * reason, wasm-bindgen appears to mishandle JsErrors when created in a Firefox web worker.
+ *
+ * See: https://github.com/wasm-bindgen/wasm-bindgen/issues/4961
+ */
+
 #[wasm_bindgen]
 impl WasmReader {
     /// Attempts to create a new `WasmReader` from an asset format and `Blob` of the asset's bytes.
@@ -32,7 +39,7 @@ impl WasmReader {
         format: &str,
         blob: &Blob,
         context_json: Option<String>,
-    ) -> Result<WasmReader, JsError> {
+    ) -> Result<WasmReader, JsString> {
         let stream = BlobStream::new(blob);
         WasmReader::from_stream(format, stream, context_json).await
     }
@@ -41,7 +48,7 @@ impl WasmReader {
         format: &str,
         stream: impl Read + Seek + Send,
         context_json: Option<String>,
-    ) -> Result<WasmReader, JsError> {
+    ) -> Result<WasmReader, JsString> {
         let reader = if let Some(json) = context_json {
             let context = Context::new()
                 .with_settings(json.as_str())
@@ -67,7 +74,7 @@ impl WasmReader {
         init: &Blob,
         fragment: &Blob,
         context_json: Option<String>,
-    ) -> Result<WasmReader, JsError> {
+    ) -> Result<WasmReader, JsString> {
         let init_stream = BlobStream::new(init);
         let fragment_stream = BlobStream::new(fragment);
 
@@ -79,7 +86,7 @@ impl WasmReader {
         init: impl Read + Seek + Send,
         fragment: impl Read + Seek + Send,
         context_json: Option<String>,
-    ) -> Result<WasmReader, JsError> {
+    ) -> Result<WasmReader, JsString> {
         let reader = if let Some(json) = context_json {
             let context = Context::new()
                 .with_settings(json.as_str())
@@ -111,7 +118,7 @@ impl WasmReader {
 
     /// Returns the asset's manifest store.
     #[wasm_bindgen(js_name = manifestStore)]
-    pub fn manifest_store(&self) -> Result<JsValue, JsError> {
+    pub fn manifest_store(&self) -> Result<JsValue, JsString> {
         let manifest_store = self
             .reader
             .serialize(&self.serializer)
@@ -122,7 +129,7 @@ impl WasmReader {
 
     /// Returns the asset's active manifest.
     #[wasm_bindgen(js_name = activeManifest)]
-    pub fn active_manifest(&self) -> Result<JsValue, JsError> {
+    pub fn active_manifest(&self) -> Result<JsValue, JsString> {
         let active_manifest = self
             .reader
             .active_manifest()
@@ -140,7 +147,7 @@ impl WasmReader {
 
     /// Accepts a URI reference to a binary object in the resource store and returns a `js_sys::Uint8Array` containing the resource's bytes.
     #[wasm_bindgen(js_name = resourceToBytes)]
-    pub fn resource_to_bytes(&self, uri: &str) -> Result<Uint8Array, JsError> {
+    pub fn resource_to_bytes(&self, uri: &str) -> Result<Uint8Array, JsString> {
         let data = Vec::new();
         let mut stream = Cursor::new(data);
 
@@ -148,6 +155,6 @@ impl WasmReader {
             .resource_to_stream(uri, &mut stream)
             .map_err(WasmError::from)?;
 
-        cursor_to_u8array(stream)
+        Ok(cursor_to_u8array(stream)?)
     }
 }

--- a/packages/c2pa-wasm/src/wasm_signer.rs
+++ b/packages/c2pa-wasm/src/wasm_signer.rs
@@ -8,12 +8,9 @@
 use async_trait::async_trait;
 use c2pa::SigningAlg;
 use c2pa::{AsyncSigner, Result as C2paResult};
-use js_sys::{
-    Error as JsError, Function as JsFunction, JsString, Number, Promise as JsPromise, Reflect,
-    Uint8Array,
-};
-use wasm_bindgen::prelude::*;
+use js_sys::{Function as JsFunction, JsString, Number, Promise as JsPromise, Reflect, Uint8Array};
 use wasm_bindgen::JsValue;
+use wasm_bindgen::prelude::*;
 use wasm_bindgen_futures::JsFuture;
 
 #[wasm_bindgen(typescript_custom_section)]
@@ -40,11 +37,18 @@ pub(crate) struct WasmSigner {
     signing_alg: SigningAlg,
 }
 
+/**
+ * NOTE: we can only return Err(JsString) or Err(JsValue) as error types here, because for some as-of-yet unknown
+ * reason, wasm-bindgen appears to mishandle JsErrors when created in a Firefox web worker.
+ *
+ * See: https://github.com/wasm-bindgen/wasm-bindgen/issues/4961
+ */
+
 #[wasm_bindgen]
 impl WasmSigner {
     /// Attempt to create a new [`WasmSigner`] from a SignerDefinition.
     #[wasm_bindgen(js_name = fromDefinition)]
-    pub fn from_definition(def: &SignerDefinition) -> Result<Self, JsError> {
+    pub fn from_definition(def: &SignerDefinition) -> Result<Self, JsString> {
         let js_value: JsValue = def.into();
 
         let reserve_size_result: Number = Reflect::get(&js_value, &"reserveSize".into())?.into();
@@ -82,16 +86,12 @@ impl AsyncSigner for WasmSigner {
             .map_err(|err| c2pa::Error::BadParam(format!("Error calling signer: {err:?}")))?
             .dyn_into()
             .map_err(|err| {
-                c2pa::Error::BadParam(format!(
-                    "Failed to convert sign result to promise: {err:?}"
-                ))
+                c2pa::Error::BadParam(format!("Failed to convert sign result to promise: {err:?}"))
             })?;
 
         let sign_result: Uint8Array = JsFuture::from(sign_promise)
             .await
-            .map_err(|err| {
-                c2pa::Error::BadParam(format!("Error awaiting sign promise: {err:?}"))
-            })?
+            .map_err(|err| c2pa::Error::BadParam(format!("Error awaiting sign promise: {err:?}")))?
             .into();
 
         let mut signed_bytes = vec![0_u8; sign_result.length() as usize];

--- a/packages/c2pa-web/src/inline.spec.ts
+++ b/packages/c2pa-web/src/inline.spec.ts
@@ -13,20 +13,23 @@ import { getBlobForAsset } from 'test/utils.js';
 import C_with_CAWG_data from 'test/assets/C_with_CAWG_data.jpg';
 import C_with_CAWG_data_untrusted_ManifestStore from 'test/manifests/C_with_CAWG_data_untrusted.js';
 
-describe('inline entrypoint', () => {
-  test('should work', async () => {
-    const c2pa = await createC2pa();
+describe.skipIf(navigator.userAgent.includes('Firefox'))(
+  'inline entrypoint',
+  () => {
+    test('should work', async () => {
+      const c2pa = await createC2pa();
 
-    const blob = await getBlobForAsset(C_with_CAWG_data);
+      const blob = await getBlobForAsset(C_with_CAWG_data);
 
-    const reader = await c2pa.reader.fromBlob(blob.type, blob);
+      const reader = await c2pa.reader.fromBlob(blob.type, blob);
 
-    expect(reader).not.toBeNull();
+      expect(reader).not.toBeNull();
 
-    const manifestStore = await reader!.manifestStore();
+      const manifestStore = await reader!.manifestStore();
 
-    expect(manifestStore).toEqual(C_with_CAWG_data_untrusted_ManifestStore);
+      expect(manifestStore).toEqual(C_with_CAWG_data_untrusted_ManifestStore);
 
-    c2pa.dispose();
-  });
-});
+      c2pa.dispose();
+    });
+  }
+);

--- a/packages/c2pa-web/src/lib/worker.ts
+++ b/packages/c2pa-web/src/lib/worker.ts
@@ -203,7 +203,7 @@ function wrapFunctions<T extends Record<string, (...args: any[]) => any>>(
 ): T {
   const wrappedFunctions = {} as Record<string, (...args: any[]) => any>;
 
-  for (let [fnName, fn] of Object.entries(functions)) {
+  for (const [fnName, fn] of Object.entries(functions)) {
     wrappedFunctions[fnName] = async (...args: any[]) => {
       try {
         return await fn(...args);

--- a/packages/c2pa-web/src/lib/worker.ts
+++ b/packages/c2pa-web/src/lib/worker.ts
@@ -25,7 +25,7 @@ const builderMap = createWorkerObjectMap<WasmBuilder>();
 const tx = createWorkerTx();
 
 rx(
-  wrapFunctions({
+  wrapFunctionsForErrorHandling({
     async initWorker(module, settings) {
       initSync({ module });
       if (settings) {
@@ -193,14 +193,12 @@ rx(
 /**
  * Wraps all functions with additional error-handling code that converts any thrown strings into Error objects.
  * This is only necessary because a bug (likely in wasm-bindgen, see https://github.com/wasm-bindgen/wasm-bindgen/issues/4961)
- * prevents the proper handling of Error objects. As a workaround, we throw strings from our wasm-bindgen
+ * prevents the proper handling of Error objects. As a workaround, we "throw" strings from our wasm-bindgen
  * functions and convert them into errors here.
- *
- * I hope that one day this can be removed :)
  */
-function wrapFunctions<T extends Record<string, (...args: any[]) => any>>(
-  functions: T
-): T {
+function wrapFunctionsForErrorHandling<
+  T extends Record<string, (...args: any[]) => any>
+>(functions: T): T {
   const wrappedFunctions = {} as Record<string, (...args: any[]) => any>;
 
   for (const [fnName, fn] of Object.entries(functions)) {

--- a/packages/c2pa-web/src/lib/worker.ts
+++ b/packages/c2pa-web/src/lib/worker.ts
@@ -24,166 +24,198 @@ const builderMap = createWorkerObjectMap<WasmBuilder>();
 
 const tx = createWorkerTx();
 
-rx({
-  async initWorker(module, settings) {
-    initSync({ module });
-    if (settings) {
-      loadSettings(settings);
-    }
-  },
-  async reader_fromBlob(format, blob, contextJson) {
-    const reader = await WasmReader.fromBlob(format, blob, contextJson);
-    const readerId = readerMap.add(reader);
-    return readerId;
-  },
-  async reader_fromBlobFragment(format, init, fragment, contextJson) {
-    const reader = await WasmReader.fromBlobFragment(
-      format,
-      init,
-      fragment,
-      contextJson
-    );
-    const readerId = readerMap.add(reader);
-    return readerId;
-  },
-  reader_activeLabel(readerId) {
-    const reader = readerMap.get(readerId);
-    return reader.activeLabel() ?? null;
-  },
-  reader_manifestStore(readerId) {
-    const reader = readerMap.get(readerId);
-    return reader.manifestStore();
-  },
-  reader_activeManifest(readerId) {
-    const reader = readerMap.get(readerId);
-    return reader.activeManifest();
-  },
-  reader_json(readerId) {
-    const reader = readerMap.get(readerId);
-    return reader.json();
-  },
-  reader_resourceToBytes(readerId, uri) {
-    const reader = readerMap.get(readerId);
-    const buffer = reader.resourceToBytes(uri) as Uint8Array<ArrayBuffer>;
-    return transfer(buffer, buffer.buffer);
-  },
-  reader_free(readerId) {
-    const reader = readerMap.get(readerId);
-    reader.free();
-    readerMap.remove(readerId);
-  },
-  builder_new(contextJson) {
-    const builder = WasmBuilder.new(contextJson);
-    const builderId = builderMap.add(builder);
-    return builderId;
-  },
-  builder_fromJson(json: string, contextJson) {
-    const builder = WasmBuilder.fromJson(json, contextJson);
-    const builderId = builderMap.add(builder);
-    return builderId;
-  },
-  builder_fromArchive(archive, contextJson) {
-    const builder = WasmBuilder.fromArchive(archive, contextJson);
-    const builderId = builderMap.add(builder);
-    return builderId;
-  },
-  builder_setIntent(builderId, intent) {
-    const builder = builderMap.get(builderId);
-    builder.setIntent(intent);
-  },
-  builder_addAction(builderId, action) {
-    const builder = builderMap.get(builderId);
-    builder.addAction(action);
-  },
-  builder_setRemoteUrl(builderId, url) {
-    const builder = builderMap.get(builderId);
-    builder.setRemoteUrl(url);
-  },
-  builder_setNoEmbed(builderId, noEmbed) {
-    const builder = builderMap.get(builderId);
-    builder.setNoEmbed(noEmbed);
-  },
-  builder_setThumbnailFromBlob(builderId, format, blob) {
-    const builder = builderMap.get(builderId);
-    builder.setThumbnailFromBlob(format, blob);
-  },
-  builder_addIngredient(builderId, json) {
-    const builder = builderMap.get(builderId);
-    builder.addIngredient(json);
-  },
-  builder_addIngredientFromBlob(builderId, json, format, blob) {
-    const builder = builderMap.get(builderId);
-    builder.addIngredientFromBlob(json, format, blob);
-  },
-  builder_addResourceFromBlob(builderId, id, blob) {
-    const builder = builderMap.get(builderId);
-    builder.addResourceFromBlob(id, blob);
-  },
-  builder_getDefinition(builderId) {
-    const builder = builderMap.get(builderId);
-    return builder.getDefinition();
-  },
-  builder_toArchive(builderId) {
-    const builder = builderMap.get(builderId);
-    const archive = builder.toArchive() as Uint8Array<ArrayBuffer>;
-    return transfer(archive, archive.buffer);
-  },
-  async builder_sign(builderId, requestId, payload, format, blob) {
-    const builder = builderMap.get(builderId);
-    const signedBytes = (await builder.sign(
-      {
-        reserveSize: payload.reserveSize,
-        alg: payload.alg,
-        sign: async (bytes) => {
-          const result = await tx.sign(
-            requestId,
-            transfer(bytes, bytes.buffer),
-            payload.reserveSize
-          );
-          return result;
-        }
-      },
-      format,
-      blob
-    )) as Uint8Array<ArrayBuffer>;
-    return transfer(signedBytes, signedBytes.buffer);
-  },
-  async builder_signAndGetManifestBytes(
-    builderId,
-    requestId,
-    payload,
-    format,
-    blob
-  ) {
-    const builder = builderMap.get(builderId);
-    const { manifest, asset } = await builder.signAndGetManifestBytes(
-      {
-        reserveSize: payload.reserveSize,
-        alg: payload.alg,
-        sign: async (bytes) => {
-          const result = await tx.sign(
-            requestId,
-            transfer(bytes, bytes.buffer),
-            payload.reserveSize
-          );
-          return result;
-        }
-      },
+rx(
+  wrapFunctions({
+    async initWorker(module, settings) {
+      initSync({ module });
+      if (settings) {
+        loadSettings(settings);
+      }
+    },
+    async reader_fromBlob(format, blob, contextJson) {
+      const reader = await WasmReader.fromBlob(format, blob, contextJson);
+      const readerId = readerMap.add(reader);
+      return readerId;
+    },
+    async reader_fromBlobFragment(format, init, fragment, contextJson) {
+      const reader = await WasmReader.fromBlobFragment(
+        format,
+        init,
+        fragment,
+        contextJson
+      );
+      const readerId = readerMap.add(reader);
+      return readerId;
+    },
+    reader_activeLabel(readerId) {
+      const reader = readerMap.get(readerId);
+      return reader.activeLabel() ?? null;
+    },
+    reader_manifestStore(readerId) {
+      const reader = readerMap.get(readerId);
+      return reader.manifestStore();
+    },
+    reader_activeManifest(readerId) {
+      const reader = readerMap.get(readerId);
+      return reader.activeManifest();
+    },
+    reader_json(readerId) {
+      const reader = readerMap.get(readerId);
+      return reader.json();
+    },
+    reader_resourceToBytes(readerId, uri) {
+      const reader = readerMap.get(readerId);
+      const buffer = reader.resourceToBytes(uri) as Uint8Array<ArrayBuffer>;
+      return transfer(buffer, buffer.buffer);
+    },
+    reader_free(readerId) {
+      const reader = readerMap.get(readerId);
+      reader.free();
+      readerMap.remove(readerId);
+    },
+    builder_new(contextJson) {
+      const builder = WasmBuilder.new(contextJson);
+      const builderId = builderMap.add(builder);
+      return builderId;
+    },
+    builder_fromJson(json: string, contextJson) {
+      const builder = WasmBuilder.fromJson(json, contextJson);
+      const builderId = builderMap.add(builder);
+      return builderId;
+    },
+    builder_fromArchive(archive, contextJson) {
+      const builder = WasmBuilder.fromArchive(archive, contextJson);
+      const builderId = builderMap.add(builder);
+      return builderId;
+    },
+    builder_setIntent(builderId, intent) {
+      const builder = builderMap.get(builderId);
+      builder.setIntent(intent);
+    },
+    builder_addAction(builderId, action) {
+      const builder = builderMap.get(builderId);
+      builder.addAction(action);
+    },
+    builder_setRemoteUrl(builderId, url) {
+      const builder = builderMap.get(builderId);
+      builder.setRemoteUrl(url);
+    },
+    builder_setNoEmbed(builderId, noEmbed) {
+      const builder = builderMap.get(builderId);
+      builder.setNoEmbed(noEmbed);
+    },
+    builder_setThumbnailFromBlob(builderId, format, blob) {
+      const builder = builderMap.get(builderId);
+      builder.setThumbnailFromBlob(format, blob);
+    },
+    builder_addIngredient(builderId, json) {
+      const builder = builderMap.get(builderId);
+      builder.addIngredient(json);
+    },
+    builder_addIngredientFromBlob(builderId, json, format, blob) {
+      const builder = builderMap.get(builderId);
+      builder.addIngredientFromBlob(json, format, blob);
+    },
+    builder_addResourceFromBlob(builderId, id, blob) {
+      const builder = builderMap.get(builderId);
+      builder.addResourceFromBlob(id, blob);
+    },
+    builder_getDefinition(builderId) {
+      const builder = builderMap.get(builderId);
+      return builder.getDefinition();
+    },
+    builder_toArchive(builderId) {
+      const builder = builderMap.get(builderId);
+      const archive = builder.toArchive() as Uint8Array<ArrayBuffer>;
+      return transfer(archive, archive.buffer);
+    },
+    async builder_sign(builderId, requestId, payload, format, blob) {
+      const builder = builderMap.get(builderId);
+      const signedBytes = (await builder.sign(
+        {
+          reserveSize: payload.reserveSize,
+          alg: payload.alg,
+          sign: async (bytes) => {
+            const result = await tx.sign(
+              requestId,
+              transfer(bytes, bytes.buffer),
+              payload.reserveSize
+            );
+            return result;
+          }
+        },
+        format,
+        blob
+      )) as Uint8Array<ArrayBuffer>;
+      return transfer(signedBytes, signedBytes.buffer);
+    },
+    async builder_signAndGetManifestBytes(
+      builderId,
+      requestId,
+      payload,
       format,
       blob
-    );
+    ) {
+      const builder = builderMap.get(builderId);
+      const { manifest, asset } = await builder.signAndGetManifestBytes(
+        {
+          reserveSize: payload.reserveSize,
+          alg: payload.alg,
+          sign: async (bytes) => {
+            const result = await tx.sign(
+              requestId,
+              transfer(bytes, bytes.buffer),
+              payload.reserveSize
+            );
+            return result;
+          }
+        },
+        format,
+        blob
+      );
 
-    return transfer(
-      {
-        manifest,
-        asset
-      },
-      [manifest.buffer, asset.buffer]
-    );
-  },
-  builder_free(builderId) {
-    const builder = builderMap.get(builderId);
-    builder.free();
-    builderMap.remove(builderId);
+      return transfer(
+        {
+          manifest,
+          asset
+        },
+        [manifest.buffer, asset.buffer]
+      );
+    },
+    builder_free(builderId) {
+      const builder = builderMap.get(builderId);
+      builder.free();
+      builderMap.remove(builderId);
+    }
+  })
+);
+
+/**
+ * Wraps all functions with additional error-handling code that converts any thrown strings into Error objects.
+ * This is only necessary because a bug (likely in wasm-bindgen, see https://github.com/wasm-bindgen/wasm-bindgen/issues/4961)
+ * prevents the proper handling of Error objects. As a workaround, we throw strings from our wasm-bindgen
+ * functions and convert them into errors here.
+ *
+ * I hope that one day this can be removed :)
+ */
+function wrapFunctions<T extends Record<string, (...args: any[]) => any>>(
+  functions: T
+): T {
+  const wrappedFunctions = {} as Record<string, (...args: any[]) => any>;
+
+  for (let [fnName, fn] of Object.entries(functions)) {
+    wrappedFunctions[fnName] = async (...args: any[]) => {
+      try {
+        return await fn(...args);
+      } catch (e) {
+        if (typeof e === 'string') {
+          throw new Error(e);
+        }
+
+        throw e;
+      }
+    };
   }
-});
+
+  return wrappedFunctions as T;
+}

--- a/packages/c2pa-web/vite.config.ts
+++ b/packages/c2pa-web/vite.config.ts
@@ -62,7 +62,11 @@ export default defineConfig(() => ({
       enabled: true,
       provider: 'playwright',
       // https://vitest.dev/guide/browser/playwright
-      instances: [{ browser: 'chromium' }],
+      instances: [
+        { browser: 'chromium' },
+        { browser: 'firefox' },
+        { browser: 'webkit' }
+      ],
       screenshotFailures: false
     }
   }


### PR DESCRIPTION
Due to some mysterious behavior (likely in wasm-bindgen), `JsError`s were not being thrown properly by wasm-bindgen generated functions. 

As a workaround, we instead report our errors as `JsString`s, which we then "convert" into Error objects at the boundary between JS/WASM.

I certainly do not love this as a fix. I am hopeful that the underlying issue in wasm-bindgen will eventually be fixed. See: https://github.com/wasm-bindgen/wasm-bindgen/issues/4961

Additionally, this PR adds Firefox and Webkit to the test runner.