### PR TITLE
build: Add cargo files to nx shared globals for cache invalidation

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -10,7 +10,11 @@
       "!{projectRoot}/.eslintrc.json",
       "!{projectRoot}/eslint.config.mjs"
     ],
-    "sharedGlobals": ["{workspaceRoot}/.github/workflows/ci.yml"]
+    "sharedGlobals": [
+      "{workspaceRoot}/.github/workflows/ci.yml",
+      "{workspaceRoot}/Cargo.toml",
+      "{workspaceRoot}/Cargo.lock"
+    ]
   },
   "plugins": [
     {


### PR DESCRIPTION
This PR adds the `Cargo.toml` and `Cargo.lock` files to the `nx.json`'s `sharedGlobals` field so that any changes to those files will also invalidate the cache.