### PR TITLE
fix: Catch panic on wasm load.

### DIFF
--- a/packages/c2pa-web/src/lib/worker/workerManager.ts
+++ b/packages/c2pa-web/src/lib/worker/workerManager.ts
@@ -64,7 +64,19 @@ export async function createWorkerManager(
     return id;
   }
 
-  await tx.initWorker(wasm, settingsString);
+  await new Promise<void>((resolve, reject) => {
+    worker.onerror = (e) => {
+      worker.onerror = null;
+      reject(e);
+    };
+    tx.initWorker(wasm, settingsString).then(
+      () => {
+        worker.onerror = null;
+        resolve();
+      },
+      reject
+    );
+  });
 
   return {
     tx,


### PR DESCRIPTION
Prevent permanent hang.
Replaced bare await tx.initWorker(...) with a wrapping Promise that:
1. Sets worker.onerror before sending the RPC — catches WASM panics / worker crashes that fire before initWorker responds
2. Clears worker.onerror on success (avoids interfering with subsequent onerror usage after init)
3. Rejects on either path — RPC rejection or ErrorEvent from worker crash

Wasm panic during __wbindgen_start → worker fires ErrorEvent → onerror fires → promise rejects → caller's catch block runs. No more permanent hang.