### PR TITLE
fix: Handle null value cases in snakeCaseify to avoid crashes

### DIFF
--- a/.changeset/seven-moons-crash.md
+++ b/.changeset/seven-moons-crash.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-web': patch
+---
+
+Add null check to avoid potential crashes.

--- a/packages/c2pa-web/src/lib/settings.spec.ts
+++ b/packages/c2pa-web/src/lib/settings.spec.ts
@@ -45,16 +45,6 @@ describe('settings', () => {
           })
         );
       });
-
-      test('should not recurse into array values', async () => {
-        // Arrays satisfy typeof val === 'object'; they should be passed through, not iterated
-        const settingsString = await settingsToWasmJson({
-          trust: { userAnchors: ['a', 'b'] as any }
-        });
-
-        const parsed = JSON.parse(settingsString);
-        expect(parsed.trust.user_anchors).toEqual(['a', 'b']);
-      });
     });
 
     describe('trust', () => {

--- a/packages/c2pa-web/src/lib/settings.spec.ts
+++ b/packages/c2pa-web/src/lib/settings.spec.ts
@@ -21,6 +21,40 @@ describe('settings', () => {
           JSON.stringify({ builder: { generate_c2pa_archive: true } })
         );
       });
+
+      test('should not throw when a settings value is null', async () => {
+        // typeof null === 'object' in JS — without a null guard this crashes
+        const settingsString = await settingsToWasmJson({
+          verify: null as any
+        });
+
+        expect(settingsString).toEqual(
+          JSON.stringify({ builder: { generate_c2pa_archive: true }, verify: null })
+        );
+      });
+
+      test('should not throw when a nested settings value is null', async () => {
+        const settingsString = await settingsToWasmJson({
+          trust: { userAnchors: null as any }
+        });
+
+        expect(settingsString).toEqual(
+          JSON.stringify({
+            builder: { generate_c2pa_archive: true },
+            trust: { user_anchors: null }
+          })
+        );
+      });
+
+      test('should not recurse into array values', async () => {
+        // Arrays satisfy typeof val === 'object'; they should be passed through, not iterated
+        const settingsString = await settingsToWasmJson({
+          trust: { userAnchors: ['a', 'b'] as any }
+        });
+
+        const parsed = JSON.parse(settingsString);
+        expect(parsed.trust.user_anchors).toEqual(['a', 'b']);
+      });
     });
 
     describe('trust', () => {

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -141,7 +141,7 @@ function snakeCaseify(object: SettingsObjectType): SettingsObjectType {
   const formattedObject = Object.entries(object).reduce(
     (formattedObject, [key, val]) => {
       formattedObject[snakeCase(key)] =
-        typeof val === 'object' ? snakeCaseify(val) : val;
+        typeof val === 'object' && val !== null && !Array.isArray(val) ? snakeCaseify(val) : val;
       return formattedObject;
     },
     {} as SettingsObjectType

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -141,7 +141,7 @@ function snakeCaseify(object: SettingsObjectType): SettingsObjectType {
   const formattedObject = Object.entries(object).reduce(
     (formattedObject, [key, val]) => {
       formattedObject[snakeCase(key)] =
-        typeof val === 'object' && val !== null && !Array.isArray(val) ? snakeCaseify(val) : val;
+        typeof val === 'object' && val !== null ? snakeCaseify(val) : val;
       return formattedObject;
     },
     {} as SettingsObjectType


### PR DESCRIPTION
Avoid crash via `TypeError` by adding a null check in `snakeCaseify()`.