### PR TITLE
fix: Add checks for valid trust keys and fetched resource response size

### DIFF
--- a/.changeset/forty-dodos-change.md
+++ b/.changeset/forty-dodos-change.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-web': patch
+---
+
+Add checks for valid trust keys, response size, and URL fetch limits

--- a/packages/c2pa-web/src/lib/settings.spec.ts
+++ b/packages/c2pa-web/src/lib/settings.spec.ts
@@ -9,7 +9,7 @@
 
 import { test, describe, expect } from 'test/methods.js';
 import { http, HttpResponse } from 'msw';
-import { settingsToWasmJson } from './settings.js';
+import { settingsToWasmJson, MAX_RESPONSE_SIZE, MAX_URLS_PER_TRUST_SETTING } from './settings.js';
 
 describe('settings', () => {
   describe('settingsToWasmJson', () => {
@@ -158,6 +158,84 @@ describe('settings', () => {
         const settingsStringPromise = settingsToWasmJson({
           trust: {
             userAnchors: 'http://userAnchorsShouldFail'
+          }
+        });
+
+        await expect(settingsStringPromise).rejects.toThrow(
+          'Failed to resolve trust settings.'
+        );
+      });
+
+      test('should not fetch URLs for unknown keys not defined in TrustSettings', async ({
+        requestMock
+      }) => {
+        let unknownKeyFetched = false;
+        requestMock.use(
+          http.get('http://unknownKey', () => {
+            unknownKeyFetched = true;
+            return HttpResponse.text('should not be fetched');
+          }),
+          http.get('http://trustAnchors', () =>
+            HttpResponse.text(
+              '-----BEGIN CERTIFICATE-----bar-----END CERTIFICATE-----'
+            )
+          )
+        );
+
+        const settingsString = await settingsToWasmJson({
+          trust: {
+            trustAnchors: 'http://trustAnchors',
+            ...(({ unknownKey: 'http://unknownKey' }) as any)
+          }
+        });
+
+        expect(unknownKeyFetched).toBe(false);
+        expect(settingsString).toContain('trust_anchors');
+      });
+
+      test('should not crash when a CawgTrustSettings boolean field is present', async () => {
+        const settingsStringPromise = settingsToWasmJson({
+          cawgTrust: {
+            verifyTrustList: true
+          }
+        });
+
+        await expect(settingsStringPromise).resolves.not.toThrow();
+      });
+
+      test('should only fetch the first MAX_URLS_PER_TRUST_SETTING URLs in an array', async ({
+        requestMock
+      }) => {
+        const CERT = '-----BEGIN CERTIFICATE-----x-----END CERTIFICATE-----';
+        const fetchedUrls: string[] = [];
+
+        requestMock.use(
+          http.get(/http:\/\/anchor-\d+/, ({ request }) => {
+            fetchedUrls.push(request.url);
+            return HttpResponse.text(CERT);
+          })
+        );
+
+        const urls = Array.from({ length: MAX_URLS_PER_TRUST_SETTING + 1 }, (_, i) => `http://anchor-${i}`);
+
+        await settingsToWasmJson({
+          trust: { userAnchors: urls }
+        });
+
+        expect(fetchedUrls.length).toBe(MAX_URLS_PER_TRUST_SETTING);
+      });
+
+      test('should throw when a fetched response exceeds the size limit', async ({
+        requestMock
+      }) => {
+        const oversizedBody = 'x'.repeat(MAX_RESPONSE_SIZE + 1);
+        requestMock.use(
+          http.get('http://oversized', () => HttpResponse.text(oversizedBody))
+        );
+
+        const settingsStringPromise = settingsToWasmJson({
+          trust: {
+            trustConfig: 'http://oversized'
           }
         });
 

--- a/packages/c2pa-web/src/lib/settings.spec.ts
+++ b/packages/c2pa-web/src/lib/settings.spec.ts
@@ -227,28 +227,6 @@ describe('settings', () => {
         await expect(settingsStringPromise).resolves.not.toThrow();
       });
 
-      test('should only fetch the first MAX_URLS_PER_TRUST_SETTING URLs in an array', async ({
-        requestMock
-      }) => {
-        const CERT = '-----BEGIN CERTIFICATE-----x-----END CERTIFICATE-----';
-        const fetchedUrls: string[] = [];
-
-        requestMock.use(
-          http.get(/http:\/\/anchor-\d+/, ({ request }) => {
-            fetchedUrls.push(request.url);
-            return HttpResponse.text(CERT);
-          })
-        );
-
-        const urls = Array.from({ length: MAX_URLS_PER_TRUST_SETTING + 1 }, (_, i) => `http://anchor-${i}`);
-
-        await settingsToWasmJson({
-          trust: { userAnchors: urls }
-        });
-
-        expect(fetchedUrls.length).toBe(MAX_URLS_PER_TRUST_SETTING);
-      });
-
       test('should throw when a fetched response exceeds the size limit', async ({
         requestMock
       }) => {

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -77,6 +77,14 @@ export interface TrustSettings {
   allowedList?: string | string[];
 }
 
+const TRUST_SETTINGS_KEY_MAP: Record<keyof TrustSettings, true> = {
+  userAnchors: true,
+  trustAnchors: true,
+  trustConfig: true,
+  allowedList: true
+};
+const TRUST_SETTINGS_KEYS = Object.keys(TRUST_SETTINGS_KEY_MAP) as (keyof TrustSettings)[];
+
 export interface CawgTrustSettings extends TrustSettings {
   /**
    * Enable CAWG trust validation. The default value is "true."
@@ -111,6 +119,9 @@ const DEFAULT_SETTINGS: Settings = {
     generateC2paArchive: true
   }
 };
+
+export const MAX_RESPONSE_SIZE = 1 * 1024 * 1024; // 1MB
+export const MAX_URLS_PER_TRUST_SETTING = 25;
 
 /**
  * Resolves any trust list URLs and serializes the resulting object into a JSON string of the structure expected by c2pa-rs.
@@ -161,9 +172,16 @@ function snakeCase(str: string): string {
  */
 async function resolveTrustSettings(settings: TrustSettings): Promise<void> {
   try {
-    const promises = Object.entries(settings).map(async ([key, val]) => {
-      if (Array.isArray(val)) {
-        const promises = val.map(async (val) => {
+    const promises = Object.entries(settings)
+    .filter(([key]) => TRUST_SETTINGS_KEYS.includes(key as keyof TrustSettings))
+    .map(async ([key, val]) => {
+      if (val && typeof val === 'object' && Array.isArray(val)) {
+        // Only fetch the first MAX_URLS_PER_TRUST_SETTING URLs to prevent excessive resource consumption.
+        const promises = val.slice(0, MAX_URLS_PER_TRUST_SETTING).map(async (val) => {
+          if (typeof val !== 'string') {
+            throw new Error('Expected a string value for array item');
+          }
+
           const text = await fetchResource(val);
 
           if (shouldValidateKey(key) && !containsCerts(text)) {
@@ -176,7 +194,7 @@ async function resolveTrustSettings(settings: TrustSettings): Promise<void> {
         const result = await Promise.all(promises);
         const combined = result.join('');
         settings[key as keyof TrustSettings] = combined;
-      } else if (val && isUrl(val)) {
+      } else if (val && typeof val === 'string' && isUrl(val)) {
         const text = await fetchResource(val);
 
         if (shouldValidateKey(key) && !containsCerts(text)) {
@@ -206,6 +224,10 @@ const isUrl = (str: string): boolean => str.startsWith('http');
 async function fetchResource(url: string): Promise<string> {
   const res = await fetch(url);
   const text = await res.text();
+
+  if (text.length > MAX_RESPONSE_SIZE) {
+    throw new Error(`Response from ${url} is too large. Max size is ${MAX_RESPONSE_SIZE} bytes.`);
+  }
 
   return text;
 }

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -121,7 +121,6 @@ const DEFAULT_SETTINGS: Settings = {
 };
 
 export const MAX_RESPONSE_SIZE = 1 * 1024 * 1024; // 1MB
-export const MAX_URLS_PER_TRUST_SETTING = 25;
 
 /**
  * Resolves any trust list URLs and serializes the resulting object into a JSON string of the structure expected by c2pa-rs.
@@ -176,8 +175,7 @@ async function resolveTrustSettings(settings: TrustSettings): Promise<void> {
     .filter(([key]) => TRUST_SETTINGS_KEYS.includes(key as keyof TrustSettings))
     .map(async ([key, val]) => {
       if (val && typeof val === 'object' && Array.isArray(val)) {
-        // Only fetch the first MAX_URLS_PER_TRUST_SETTING URLs to prevent excessive resource consumption.
-        const promises = val.slice(0, MAX_URLS_PER_TRUST_SETTING).map(async (val) => {
+        const promises = val.map(async (val) => {
           if (typeof val !== 'string') {
             throw new Error('Expected a string value for array item');
           }


### PR DESCRIPTION
This PR adds the following guards and checks to the `resolveTrustSettings` API:
- Only process keys in the `TrustSettings` interface when resolving the passed-in trust settings (other keys could exist, such as those in an extending interface like `CawgTrustSettings`), which are known to be the ones that we want to actually process.
- Cap responses from fetching resources from trust URLs to 1MB, which should be a generous upper bound on what a realistic trust anchor or config file could reach. Anything over that size will throw an error. 