### PR TITLE
feat: Improve error handling when fetching trust anchors

### DIFF
--- a/.changeset/slow-baboons-dig.md
+++ b/.changeset/slow-baboons-dig.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-web': patch
+---
+
+Improve error handling when resolving trust anchors.

--- a/packages/c2pa-web/src/lib/settings.spec.ts
+++ b/packages/c2pa-web/src/lib/settings.spec.ts
@@ -190,6 +190,26 @@ describe('settings', () => {
         );
       });
 
+      test('should report a meaningful error when a trust URL returns a non-OK HTTP response', async ({
+        requestMock
+      }) => {
+        requestMock.use(
+          http.get('http://userAnchors429', () =>
+            new HttpResponse(null, { status: 429, statusText: 'Too Many Requests' })
+          )
+        );
+
+        const settingsStringPromise = settingsToWasmJson({
+          trust: {
+            userAnchors: 'http://userAnchors429'
+          }
+        });
+
+        await expect(settingsStringPromise).rejects.toThrow(
+          'Failed to fetch http://userAnchors429: 429'
+        );
+      });
+
       test('should not fetch URLs for unknown keys not defined in TrustSettings', async ({
         requestMock
       }) => {

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -207,7 +207,8 @@ async function resolveTrustSettings(settings: TrustSettings): Promise<void> {
 
     await Promise.all(promises);
   } catch (e) {
-    throw new Error('Failed to resolve trust settings.', { cause: e });
+    const message = e instanceof Error ? e.message : String(e);
+    throw new Error(`Failed to resolve trust settings. ${message}`, { cause: e });
   }
 }
 
@@ -220,7 +221,18 @@ const containsCerts = (content: string): boolean =>
 const isUrl = (str: string): boolean => str.startsWith('http');
 
 async function fetchResource(url: string): Promise<string> {
-  const res = await fetch(url);
+  let res: Response;
+  try {
+    res = await fetch(url);
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    throw new Error(`Network error fetching ${url}: ${message}`, { cause: e });
+  }
+
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+  }
+
   const text = await res.text();
 
   if (text.length > MAX_RESPONSE_SIZE) {


### PR DESCRIPTION
- Includes the error message directly when throwing the `Error` object in `resolveTrustSettings`
- Handle failed `fetch` calls when fetching a resource by wrapping the call in a try-catch block and reporting different error messages based on what actually happened. Network errors can be differentiated from actual errors coming from the fetch (e.g. 429, 404, etc.).