### PR TITLE
feat: add workerSrc config option for CSP-restricted environments

### DIFF
--- a/.changeset/tiny-jars-say.md
+++ b/.changeset/tiny-jars-say.md
@@ -1,0 +1,7 @@
+---
+'@contentauth/c2pa-web': minor
+'@contentauth/c2pa-types': minor
+'@contentauth/c2pa-wasm': minor
+---
+
+add workerSrc config option for CSP-restricted environments

--- a/packages/c2pa-web/package.json
+++ b/packages/c2pa-web/package.json
@@ -26,6 +26,11 @@
       "types": "./dist/inline.d.ts",
       "import": "./dist/inline.js",
       "default": "./dist/inline.js"
+    },
+    "./worker": {
+      "development": "./src/lib/worker.ts",
+      "import": "./dist/worker.js",
+      "default": "./dist/worker.js"
     }
   },
   "publishConfig": {
@@ -41,6 +46,10 @@
         "types": "./dist/inline.d.ts",
         "import": "./dist/inline.js",
         "default": "./dist/inline.js"
+      },
+      "./worker": {
+        "import": "./dist/worker.js",
+        "default": "./dist/worker.js"
       }
     }
   },

--- a/packages/c2pa-web/src/lib/c2pa.ts
+++ b/packages/c2pa-web/src/lib/c2pa.ts
@@ -19,6 +19,16 @@ export interface Config {
   wasmSrc: string | WebAssembly.Module;
 
   /**
+   * HTTPS URL to the worker script. When provided the worker is loaded from this
+   * URL instead of an inline blob URL, which is required in environments
+   * with a strict Content Security Policy that disallows blob: worker sources.
+   *
+   * Host the file exported as `@contentauth/c2pa-web/worker` alongside your
+   * application and pass its URL here.
+   */
+  workerSrc?: URL;
+
+  /**
    * Settings for the SDK. Will be inherited by created builders and readers.
    */
   settings?: Settings;
@@ -42,13 +52,13 @@ export interface C2paSdk {
 }
 
 export async function createC2pa(config: Config): Promise<C2paSdk> {
-  const { wasmSrc, settings } = config;
+  const { wasmSrc, workerSrc, settings } = config;
 
   const wasm =
     typeof wasmSrc === 'string' ? await fetchAndCompileWasm(wasmSrc) : wasmSrc;
 
   const settingsString = await resolveSettings(settings, undefined);
-  const worker = await createWorkerManager({ wasm, settingsString });
+  const worker = await createWorkerManager({ wasm, workerSrc, settingsString });
 
   return {
     reader: createReaderFactory(worker, settings),

--- a/packages/c2pa-web/src/lib/worker/workerManager.ts
+++ b/packages/c2pa-web/src/lib/worker/workerManager.ts
@@ -9,7 +9,7 @@
 
 import { Signer } from '../signer.js';
 import { createTx, workerRx } from './rpc.js';
-import Worker from '../worker?worker&inline';
+import InlineWorker from '../worker?worker&inline';
 import { transfer } from 'highgain';
 
 export interface WorkerManager {
@@ -21,6 +21,26 @@ export interface WorkerManager {
 export interface CreateWorkerManagerConfig {
   wasm: WebAssembly.Module;
   settingsString?: string;
+  workerSrc?: URL;
+}
+
+/**
+ * Validates a worker source URL before it is loaded into a Worker. The value
+ * must be a structurally valid URL served over https, since arbitrary or
+ * insecure sources would let untrusted code run in the worker context.
+ *
+ * @param workerSrc - the worker source URL to validate
+ * @returns the normalized URL string, safe to pass to `new Worker`
+ * @throws if the value is not a valid URL or does not use https
+ */
+export function validateWorkerSrc(workerSrc: URL): string {
+  if (workerSrc.protocol !== 'https:') {
+    throw new Error(
+      `Worker source URL must use https, but got ${workerSrc.protocol}`
+    );
+  }
+
+  return workerSrc.toString();
 }
 
 /**
@@ -34,10 +54,12 @@ export interface CreateWorkerManagerConfig {
 export async function createWorkerManager(
   config: CreateWorkerManagerConfig
 ): Promise<WorkerManager> {
-  const { wasm, settingsString } = config;
+  const { wasm, settingsString, workerSrc } = config;
   let signerRequestId = 0;
 
-  const worker = new Worker();
+  const worker = workerSrc
+    ? new Worker(validateWorkerSrc(workerSrc))
+    : new InlineWorker();
 
   const tx = createTx(worker);
 

--- a/packages/c2pa-web/vite.config.ts
+++ b/packages/c2pa-web/vite.config.ts
@@ -44,7 +44,8 @@ export default defineConfig(() => ({
     lib: {
       entry: {
         index: 'src/index.ts',
-        inline: 'src/inline.ts'
+        inline: 'src/inline.ts',
+        worker: 'src/lib/worker.ts'
       },
       name: '@contentauth/c2pa-web',
       // Change this to the formats you want to support.


### PR DESCRIPTION
## Summary

- Add `workerSrc?: URL` to the `Config` interface in `createC2pa` — when provided, the worker is loaded from this HTTPS URL instead of an inline blob URL
- Thread `workerSrc` through `createWorkerManager`; fall back to `InlineWorker` (existing blob behaviour) when omitted — fully backwards compatible
- Add `validateWorkerSrc` which enforces https protocol before the URL is passed to the Worker constructor, preventing insecure worker sources
- Worker is created as a classic script (no `type: 'module'`) since the hosted file is a self-contained IIFE

## Motivation

Environments with a strict Content Security Policy (`worker-src 'self'`) block blob: worker URLs. This change allows consumers to host the worker script at an HTTPS URL on the same origin as their app and pass it via `workerSrc`, bypassing the CSP restriction while keeping the existing inline blob as the default for unconstrained environments.

## Usage

```ts
const c2pa = await createC2pa({
  wasmSrc: 'https://cdn.example.com/c2pa_bg.wasm',
  workerSrc: new URL('https://cdn.example.com/c2pa_worker.js'),
});
```

## Test plan

- [ ] Existing tests pass (no behaviour change when `workerSrc` is omitted)
- [ ] Manual test: pass a valid `workerSrc` URL and verify worker initialises without blob URL
- [ ] Manual test: omit `workerSrc` and verify existing blob fallback still works
- [ ] Manual test: pass a non-https URL and verify `validateWorkerSrc` throws

🤖 Generated with [Claude Code](https://claude.com/claude-code)