### PR TITLE
feat: bundle c2pa_worker.js as self-contained ESM for direct workerSrc use

### DIFF
--- a/.changeset/strict-drinks-watch.md
+++ b/.changeset/strict-drinks-watch.md
@@ -5,3 +5,5 @@
 ---
 
 Bundle c2pa_worker.js as self-contained ESM so consumers can use workerSrc without a bundler
+
+**Breaking change for `@contentauth/c2pa-web` 0.10.0**: the package export subpath has been renamed from `./worker` to `./c2pa_worker`. Update any import or workerSrc path accordingly.

--- a/.changeset/strict-drinks-watch.md
+++ b/.changeset/strict-drinks-watch.md
@@ -1,0 +1,7 @@
+---
+'@contentauth/c2pa-types': minor
+'@contentauth/c2pa-wasm': minor
+'@contentauth/c2pa-web': minor
+---
+
+Bundle c2pa_worker.js as self-contained ESM so consumers can use workerSrc without a bundler

--- a/packages/c2pa-web/package.json
+++ b/packages/c2pa-web/package.json
@@ -27,10 +27,10 @@
       "import": "./dist/inline.js",
       "default": "./dist/inline.js"
     },
-    "./worker": {
+    "./c2pa_worker": {
       "development": "./src/lib/worker.ts",
-      "import": "./dist/worker.js",
-      "default": "./dist/worker.js"
+      "import": "./dist/c2pa_worker.js",
+      "default": "./dist/c2pa_worker.js"
     }
   },
   "publishConfig": {
@@ -47,9 +47,9 @@
         "import": "./dist/inline.js",
         "default": "./dist/inline.js"
       },
-      "./worker": {
-        "import": "./dist/worker.js",
-        "default": "./dist/worker.js"
+      "./c2pa_worker": {
+        "import": "./dist/c2pa_worker.js",
+        "default": "./dist/c2pa_worker.js"
       }
     }
   },

--- a/packages/c2pa-web/src/lib/c2pa.ts
+++ b/packages/c2pa-web/src/lib/c2pa.ts
@@ -23,7 +23,7 @@ export interface Config {
    * URL instead of an inline blob URL, which is required in environments
    * with a strict Content Security Policy that disallows blob: worker sources.
    *
-   * Host the file exported as `@contentauth/c2pa-web/worker` alongside your
+   * Host the file exported as `@contentauth/c2pa-web/c2pa_worker` alongside your
    * application and pass its URL here.
    */
   workerSrc?: URL;

--- a/packages/c2pa-web/src/lib/worker/workerManager.ts
+++ b/packages/c2pa-web/src/lib/worker/workerManager.ts
@@ -58,7 +58,7 @@ export async function createWorkerManager(
   let signerRequestId = 0;
 
   const worker = workerSrc
-    ? new Worker(validateWorkerSrc(workerSrc))
+    ? new Worker(validateWorkerSrc(workerSrc), { type: 'module' })
     : new InlineWorker();
 
   const tx = createTx(worker);

--- a/packages/c2pa-web/vite.config.ts
+++ b/packages/c2pa-web/vite.config.ts
@@ -6,7 +6,7 @@
  * accordance with the terms of the Adobe license agreement accompanying
  * it.
  */
-import { defineConfig, Plugin } from 'vite';
+import { defineConfig, Plugin, build } from 'vite';
 import dts from 'vite-plugin-dts';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import { workspaceRoot } from '@nx/devkit';
@@ -45,7 +45,7 @@ export default defineConfig(() => ({
       entry: {
         index: 'src/index.ts',
         inline: 'src/inline.ts',
-        worker: 'src/lib/worker.ts'
+        c2pa_worker: 'src/lib/worker.ts'
       },
       name: '@contentauth/c2pa-web',
       // Change this to the formats you want to support.
@@ -103,6 +103,26 @@ function createBuildPlugin(): Plugin {
 
       mkdirSync(pkgResourceDir, { recursive: true });
       linkSync(wasmResourcePath, pkgResourcePath);
+    },
+    async closeBundle() {
+      // Overwrite the Vite-built worker.js with a fully self-contained bundle
+      // so that consumers can use it directly via workerSrc without needing
+      // a bundler to resolve bare specifiers like 'highgain'.
+      await build({
+        configFile: false,
+        build: {
+          lib: {
+            entry: join(__dirname, 'src/lib/worker.ts'),
+            formats: ['es'],
+            fileName: () => 'c2pa_worker.js',
+          },
+          outDir: join(__dirname, 'dist'),
+          emptyOutDir: false,
+          rollupOptions: {
+            external: ['@contentauth/c2pa-types'],
+          },
+        },
+      });
     }
   };
 }

--- a/packages/c2pa-web/vite.config.ts
+++ b/packages/c2pa-web/vite.config.ts
@@ -45,7 +45,6 @@ export default defineConfig(() => ({
       entry: {
         index: 'src/index.ts',
         inline: 'src/inline.ts',
-        c2pa_worker: 'src/lib/worker.ts'
       },
       name: '@contentauth/c2pa-web',
       // Change this to the formats you want to support.
@@ -105,9 +104,6 @@ function createBuildPlugin(): Plugin {
       linkSync(wasmResourcePath, pkgResourcePath);
     },
     async closeBundle() {
-      // Overwrite the Vite-built worker.js with a fully self-contained bundle
-      // so that consumers can use it directly via workerSrc without needing
-      // a bundler to resolve bare specifiers like 'highgain'.
       await build({
         configFile: false,
         build: {


### PR DESCRIPTION
## Summary

- Add a `closeBundle` hook that re-bundles the worker using Vite's `build()` API, inlining `highgain` and all internal imports so consumers can load it directly via `workerSrc` without needing their own bundler to resolve bare specifiers
- Rename worker build entry to `c2pa_worker` so the output is `dist/c2pa_worker.js`
- Pass `{ type: 'module' }` when constructing a `Worker` from `workerSrc`, required for ESM module workers