### PR TITLE
chore: Update c2pa dependency version to 0.88.0

### DIFF
--- a/.changeset/twenty-planes-argue.md
+++ b/.changeset/twenty-planes-argue.md
@@ -1,0 +1,7 @@
+---
+'@contentauth/c2pa-types': minor
+'@contentauth/c2pa-wasm': minor
+'@contentauth/c2pa-web': minor
+---
+
+Bump c2pa-rs version to v0.88.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-c2pa = { version = "=0.85.2", features = ["pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
+c2pa = { version = "=0.88.0", features = ["pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
Bump c2pa-rs version to latest: https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-v0.88.0