### PR TITLE
fix: Remove standalone-repo options from c2pa-node typedoc config

### DIFF
--- a/packages/c2pa-node/typedoc.json
+++ b/packages/c2pa-node/typedoc.json
@@ -1,6 +1,4 @@
 {
   "entryPoints": ["js-src/index.ts"],
-  "out": "docs",
-  "readme": "README.md",
   "includeVersion": false
 }


### PR DESCRIPTION
`'out'` and `'readme'` are left over from when c2pa-node lived in its own repo. In the monorepo, entryPointStrategy=packages means the root typedoc.json controls output; per-package 'out' is ignored. Removing for consistency with c2pa-web, c2pa-types, and c2pa-wasm.