### PR TITLE
fix: eliminate repeated JS/WASM boundary crossings in BlobStream

### DIFF
--- a/.changeset/loose-dogs-design.md
+++ b/.changeset/loose-dogs-design.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-wasm': minor
+---
+
+Eliminate repeated JS/WASM boundary crossings in BlobStream

--- a/.changeset/loose-dogs-design.md
+++ b/.changeset/loose-dogs-design.md
@@ -1,5 +1,5 @@
 ---
-'@contentauth/c2pa-wasm': minor
+'@contentauth/c2pa-wasm': patch
 ---
 
 Eliminate repeated JS/WASM boundary crossings in BlobStream

--- a/packages/c2pa-wasm/src/stream/blob_stream.rs
+++ b/packages/c2pa-wasm/src/stream/blob_stream.rs
@@ -5,31 +5,76 @@
 // accordance with the terms of the Adobe license agreement accompanying
 // it.
 
-use std::io::{Error as IoError, Read, Result as IoResult, Seek, SeekFrom};
+use std::{
+    cmp::min,
+    io::{Cursor, Error as IoError, Read, Result as IoResult, Seek, SeekFrom},
+};
 
 use js_sys::Uint8Array;
 use web_sys::{Blob, FileReaderSync};
 
-/// Wraps a JS-space Blob and a byte offset to support the implementation of Read + Seek.
-pub struct BlobStream<'a> {
-    offset: u64,
-    blob: &'a Blob,
+/// Files at or below this size are read entirely into WASM memory on construction,
+/// eliminating repeated JS/WASM boundary crossings. Larger files fall back to
+/// per-read `Blob.slice()` to avoid excessive memory duplication.
+const BUFFER_THRESHOLD_BYTES: usize = 50 * 1024 * 1024; // 50 MB
+
+enum StreamImpl {
+    /// Entire blob pre-loaded into WASM memory. All Read/Seek ops are pure in-memory.
+    Buffered(Cursor<Vec<u8>>),
+    /// Original lazy approach: each read() crosses the JS/WASM boundary via Blob.slice().
+    Lazy { offset: usize, blob: Blob },
 }
 
-impl<'a> BlobStream<'a> {
+/// Wraps a JS-space Blob to support Read + Seek.
+///
+/// For blobs <= 50 MB the data is eagerly copied into WASM linear memory so that
+/// subsequent reads and seeks are pure in-memory operations - no JS interop overhead.
+/// Larger blobs use a lazy per-read strategy to avoid doubling memory usage.
+pub struct BlobStream {
+    inner: StreamImpl,
+}
+
+impl BlobStream {
     /// Create a new BlobStream from a `web_sys::Blob`.
-    pub fn new(blob: &'a Blob) -> Self {
-        Self { offset: 0, blob }
+    pub fn new(blob: &Blob) -> Self {
+        let size = blob.size() as usize;
+        if size <= BUFFER_THRESHOLD_BYTES {
+            let data = read_entire_blob(blob).unwrap_or_default();
+            Self {
+                inner: StreamImpl::Buffered(Cursor::new(data)),
+            }
+        } else {
+            Self {
+                inner: StreamImpl::Lazy {
+                    offset: 0,
+                    blob: blob.clone(),
+                },
+            }
+        }
     }
 }
 
-impl Read for BlobStream<'_> {
-    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
-        let mut slice: &[u8] = &get_vec_u8_from_blob(self.blob, self.offset, buf.len())?;
-        let bytes_read = slice.read(buf)?;
-        self.offset += bytes_read as u64;
-        Ok(bytes_read)
+fn read_entire_blob(blob: &Blob) -> IoResult<Vec<u8>> {
+    let size = blob.size() as usize;
+    if size == 0 {
+        return Ok(Vec::new());
     }
+
+    let reader_sync = FileReaderSync::new().map_err(|err| {
+        IoError::other(format!(
+            "Failed to create FileReaderSync. Details: {err:?}"
+        ))
+    })?;
+
+    let array_buffer = reader_sync
+        .read_as_array_buffer(blob)
+        .map_err(|err| IoError::other(format!("Failed to read blob. Details: {err:?}")))?;
+
+    let u8array = Uint8Array::new(&array_buffer);
+    let mut buf = vec![0u8; u8array.byte_length() as usize];
+    u8array.copy_to(&mut buf);
+
+    Ok(buf)
 }
 
 fn get_vec_u8_from_blob(blob: &Blob, offset: u64, len: usize) -> IoResult<Vec<u8>> {
@@ -59,42 +104,44 @@ fn get_vec_u8_from_blob(blob: &Blob, offset: u64, len: usize) -> IoResult<Vec<u8
     Ok(buf)
 }
 
-impl Seek for BlobStream<'_> {
-    fn seek(&mut self, pos: SeekFrom) -> std::io::Result<u64> {
-        let new_offset: u64 = match pos {
-            SeekFrom::Start(offset) => offset,
-            SeekFrom::End(offset) => {
-                let pos = (self.blob.size() as i64)
-                    .checked_add(offset)
-                    .ok_or_else(|| IoError::other("seek overflow"))?;
-                if pos < 0 {
-                    return Err(IoError::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "seek before start of stream",
-                    ));
-                }
-                pos as u64
+impl Read for BlobStream {
+    fn read(&mut self, buf: &mut [u8]) -> IoResult<usize> {
+        match &mut self.inner {
+            StreamImpl::Buffered(cursor) => cursor.read(buf),
+            StreamImpl::Lazy { offset, blob } => {
+                let mut slice: &[u8] = &get_vec_u8_from_blob(blob, *offset, buf.len())?;
+                let bytes_read = slice.read(buf)?;
+                *offset += bytes_read;
+                Ok(bytes_read)
             }
-            SeekFrom::Current(offset) => {
-                let pos = (self.offset as i64)
-                    .checked_add(offset)
-                    .ok_or_else(|| IoError::other("seek overflow"))?;
-                if pos < 0 {
-                    return Err(IoError::new(
-                        std::io::ErrorKind::InvalidInput,
-                        "seek before start of stream",
-                    ));
+        }
+    }
+}
+
+impl Seek for BlobStream {
+    fn seek(&mut self, pos: SeekFrom) -> IoResult<u64> {
+        match &mut self.inner {
+            StreamImpl::Buffered(cursor) => cursor.seek(pos),
+            StreamImpl::Lazy { offset, blob } => {
+                match pos {
+                    SeekFrom::Start(o) => {
+                        *offset = o as usize;
+                    }
+                    SeekFrom::End(o) => {
+                        *offset = (blob.size() as i64 + o) as usize;
+                    }
+                    SeekFrom::Current(o) => {
+                        *offset = (*offset as i64 + o) as usize;
+                    }
                 }
-                pos as u64
+                Ok(*offset as u64)
             }
-        };
-        self.offset = new_offset;
-        Ok(self.offset)
+        }
     }
 }
 
 // SAFETY: WASM is single-threaded.
-unsafe impl Send for BlobStream<'_> {}
+unsafe impl Send for BlobStream {}
 
 #[cfg(test)]
 mod tests {

--- a/packages/c2pa-wasm/src/stream/blob_stream.rs
+++ b/packages/c2pa-wasm/src/stream/blob_stream.rs
@@ -15,7 +15,7 @@ use web_sys::{Blob, FileReaderSync};
 /// per-read `Blob.slice()` to avoid excessive memory duplication.
 const BUFFER_THRESHOLD_BYTES: usize = 50 * 1024 * 1024; // 50 MB
 
-enum StreamImpl {
+pub(crate) enum StreamImpl {
     /// Entire blob pre-loaded into WASM memory. All Read/Seek ops are pure in-memory.
     Buffered(Cursor<Vec<u8>>),
     /// Original lazy approach: each read() crosses the JS/WASM boundary via Blob.slice().
@@ -28,14 +28,18 @@ enum StreamImpl {
 /// subsequent reads and seeks are pure in-memory operations - no JS interop overhead.
 /// Larger blobs use a lazy per-read strategy to avoid doubling memory usage.
 pub struct BlobStream {
-    inner: StreamImpl,
+    pub(crate) inner: StreamImpl,
 }
 
 impl BlobStream {
     /// Create a new BlobStream from a `web_sys::Blob`.
     pub fn new(blob: &Blob) -> Self {
+        Self::new_with_threshold(blob, BUFFER_THRESHOLD_BYTES)
+    }
+
+    fn new_with_threshold(blob: &Blob, threshold: usize) -> Self {
         let size = blob.size() as usize;
-        if size <= BUFFER_THRESHOLD_BYTES {
+        if size <= threshold {
             let data = read_entire_blob(blob).unwrap_or_default();
             Self {
                 inner: StreamImpl::Buffered(Cursor::new(data)),
@@ -246,5 +250,102 @@ mod tests {
         parts.push(&u8array);
 
         Blob::new_with_u8_array_sequence(&parts).unwrap()
+    }
+
+    /// Creates a BlobStream that always uses the Lazy strategy, regardless of blob size.
+    fn lazy_stream(blob: &Blob) -> BlobStream {
+        // threshold of 0 forces the Lazy path for any non-empty blob
+        BlobStream::new_with_threshold(blob, 0)
+    }
+
+    // Lazy-path equivalents of the Buffered tests
+
+    #[wasm_bindgen_test]
+    fn test_lazy_read_in_sequence() {
+        let blob = blob_from_vec(vec![0, 1, 2, 3]);
+        let mut stream = lazy_stream(&blob);
+
+        let mut buf = vec![0; 2];
+        let bytes_read = stream.read(&mut buf).unwrap();
+        assert_eq!(buf, vec![0, 1]);
+        assert_eq!(bytes_read, 2);
+
+        let mut next_buf = vec![0; 2];
+        let next_bytes_read = stream.read(&mut next_buf).unwrap();
+        assert_eq!(next_buf, vec![2, 3]);
+        assert_eq!(next_bytes_read, 2);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_lazy_read_into_oversize_buffer() {
+        let blob = blob_from_vec(vec![0, 1, 2, 3]);
+        let mut stream = lazy_stream(&blob);
+
+        let mut buf = vec![0; 6];
+        let bytes_read = stream.read(&mut buf).unwrap();
+        assert_eq!(buf, vec![0, 1, 2, 3, 0, 0]);
+        assert_eq!(bytes_read, 4);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_lazy_read_and_seek() {
+        let blob = blob_from_vec(vec![0, 1, 2, 3]);
+        let mut stream = lazy_stream(&blob);
+
+        stream.seek(SeekFrom::Start(2)).unwrap();
+        let mut buf = vec![0; 2];
+        stream.read(&mut buf).unwrap();
+        assert_eq!(buf, vec![2, 3]);
+
+        stream.seek(SeekFrom::Current(-4)).unwrap();
+        let mut next_buf = vec![0; 2];
+        stream.read(&mut next_buf).unwrap();
+        assert_eq!(next_buf, vec![0, 1]);
+
+        stream.seek(SeekFrom::End(-2)).unwrap();
+        let mut final_buf = vec![0; 2];
+        stream.read(&mut final_buf).unwrap();
+        assert_eq!(final_buf, vec![2, 3]);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_lazy_seek_past_end_and_read() {
+        let blob = blob_from_vec(vec![0, 1, 2, 3]);
+        let mut stream = lazy_stream(&blob);
+
+        stream.seek(SeekFrom::Start(10)).unwrap();
+        let mut buf = vec![0; 2];
+        let bytes_read = stream.read(&mut buf).unwrap();
+        assert_eq!(bytes_read, 0);
+    }
+
+    // Threshold boundary
+
+    #[wasm_bindgen_test]
+    fn test_blob_at_threshold_uses_buffered_path() {
+        // A blob exactly at the threshold should use the Buffered path.
+        let data = vec![42u8; 4];
+        let blob = blob_from_vec(data.clone());
+        // threshold == blob size => Buffered
+        let mut stream = BlobStream::new_with_threshold(&blob, 4);
+        assert!(matches!(stream.inner, StreamImpl::Buffered(_)));
+
+        let mut buf = vec![0u8; 4];
+        stream.read(&mut buf).unwrap();
+        assert_eq!(buf, data);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_blob_above_threshold_uses_lazy_path() {
+        // A blob one byte above the threshold should use the Lazy path.
+        let data = vec![7u8; 5];
+        let blob = blob_from_vec(data.clone());
+        // threshold == blob size - 1 => Lazy
+        let mut stream = BlobStream::new_with_threshold(&blob, 4);
+        assert!(matches!(stream.inner, StreamImpl::Lazy { .. }));
+
+        let mut buf = vec![0u8; 5];
+        stream.read(&mut buf).unwrap();
+        assert_eq!(buf, data);
     }
 }

--- a/packages/c2pa-wasm/src/stream/blob_stream.rs
+++ b/packages/c2pa-wasm/src/stream/blob_stream.rs
@@ -5,10 +5,7 @@
 // accordance with the terms of the Adobe license agreement accompanying
 // it.
 
-use std::{
-    cmp::min,
-    io::{Cursor, Error as IoError, Read, Result as IoResult, Seek, SeekFrom},
-};
+use std::io::{Cursor, Error as IoError, Read, Result as IoResult, Seek, SeekFrom};
 
 use js_sys::Uint8Array;
 use web_sys::{Blob, FileReaderSync};
@@ -109,7 +106,7 @@ impl Read for BlobStream {
         match &mut self.inner {
             StreamImpl::Buffered(cursor) => cursor.read(buf),
             StreamImpl::Lazy { offset, blob } => {
-                let mut slice: &[u8] = &get_vec_u8_from_blob(blob, *offset, buf.len())?;
+                let mut slice: &[u8] = &get_vec_u8_from_blob(blob, *offset as u64, buf.len())?;
                 let bytes_read = slice.read(buf)?;
                 *offset += bytes_read;
                 Ok(bytes_read)

--- a/packages/c2pa-wasm/src/stream/blob_stream.rs
+++ b/packages/c2pa-wasm/src/stream/blob_stream.rs
@@ -11,7 +11,7 @@ use js_sys::Uint8Array;
 use web_sys::{Blob, FileReaderSync};
 
 /// Files at or below this size are read entirely into WASM memory on construction,
-/// eliminating repeated JS/WASM boundary crossings. Larger files fall back to
+/// eliminating repeated JS/WASM boundary crossings. Larger files use a lazy
 /// per-read `Blob.slice()` to avoid excessive memory duplication.
 const BUFFER_THRESHOLD_BYTES: usize = 50 * 1024 * 1024; // 50 MB
 
@@ -19,7 +19,7 @@ pub(crate) enum StreamImpl {
     /// Entire blob pre-loaded into WASM memory. All Read/Seek ops are pure in-memory.
     Buffered(Cursor<Vec<u8>>),
     /// Original lazy approach: each read() crosses the JS/WASM boundary via Blob.slice().
-    Lazy { offset: usize, blob: Blob },
+    Lazy { offset: u64, blob: Blob },
 }
 
 /// Wraps a JS-space Blob to support Read + Seek.
@@ -33,24 +33,24 @@ pub struct BlobStream {
 
 impl BlobStream {
     /// Create a new BlobStream from a `web_sys::Blob`.
-    pub fn new(blob: &Blob) -> Self {
+    pub fn new(blob: &Blob) -> IoResult<Self> {
         Self::new_with_threshold(blob, BUFFER_THRESHOLD_BYTES)
     }
 
-    fn new_with_threshold(blob: &Blob, threshold: usize) -> Self {
+    fn new_with_threshold(blob: &Blob, threshold: usize) -> IoResult<Self> {
         let size = blob.size() as usize;
         if size <= threshold {
-            let data = read_entire_blob(blob).unwrap_or_default();
-            Self {
+            let data = read_entire_blob(blob)?;
+            Ok(Self {
                 inner: StreamImpl::Buffered(Cursor::new(data)),
-            }
+            })
         } else {
-            Self {
+            Ok(Self {
                 inner: StreamImpl::Lazy {
                     offset: 0,
                     blob: blob.clone(),
                 },
-            }
+            })
         }
     }
 }
@@ -79,7 +79,10 @@ fn read_entire_blob(blob: &Blob) -> IoResult<Vec<u8>> {
 }
 
 fn get_vec_u8_from_blob(blob: &Blob, offset: u64, len: usize) -> IoResult<Vec<u8>> {
-    let end = (blob.size() as u64).min(offset + len as u64);
+    // blob.size() is f64; safe to cast to u64 because wasm32 linear memory caps at ~4 GB.
+    // saturating_add: offset is bounded by i64::MAX (seek rejects larger values), so
+    // overflow is unreachable in practice, but saturating keeps the invariant local.
+    let end = (blob.size() as u64).min(offset.saturating_add(len as u64));
     let slice = blob
         .slice_with_f64_and_f64(offset as f64, end as f64)
         .map_err(|err| {
@@ -110,9 +113,9 @@ impl Read for BlobStream {
         match &mut self.inner {
             StreamImpl::Buffered(cursor) => cursor.read(buf),
             StreamImpl::Lazy { offset, blob } => {
-                let mut slice: &[u8] = &get_vec_u8_from_blob(blob, *offset as u64, buf.len())?;
+                let mut slice: &[u8] = &get_vec_u8_from_blob(blob, *offset, buf.len())?;
                 let bytes_read = slice.read(buf)?;
-                *offset += bytes_read;
+                *offset += bytes_read as u64;
                 Ok(bytes_read)
             }
         }
@@ -124,18 +127,25 @@ impl Seek for BlobStream {
         match &mut self.inner {
             StreamImpl::Buffered(cursor) => cursor.seek(pos),
             StreamImpl::Lazy { offset, blob } => {
-                match pos {
-                    SeekFrom::Start(o) => {
-                        *offset = o as usize;
-                    }
-                    SeekFrom::End(o) => {
-                        *offset = (blob.size() as i64 + o) as usize;
-                    }
-                    SeekFrom::Current(o) => {
-                        *offset = (*offset as i64 + o) as usize;
-                    }
+                let new_offset: i64 = match pos {
+                    SeekFrom::Start(o) => i64::try_from(o).map_err(|_| {
+                        IoError::new(std::io::ErrorKind::InvalidInput, "seek overflow")
+                    })?,
+                    SeekFrom::End(o) => (blob.size() as i64)
+                        .checked_add(o)
+                        .ok_or_else(|| IoError::new(std::io::ErrorKind::InvalidInput, "seek overflow"))?,
+                    SeekFrom::Current(o) => (*offset as i64)
+                        .checked_add(o)
+                        .ok_or_else(|| IoError::new(std::io::ErrorKind::InvalidInput, "seek overflow"))?,
+                };
+                if new_offset < 0 {
+                    return Err(IoError::new(
+                        std::io::ErrorKind::InvalidInput,
+                        "seek before start of stream",
+                    ));
                 }
-                Ok(*offset as u64)
+                *offset = new_offset as u64;
+                Ok(*offset)
             }
         }
     }
@@ -157,7 +167,7 @@ mod tests {
     fn test_read_in_sequence() {
         let blob = blob_from_vec(vec![0, 1, 2, 3]);
 
-        let mut stream = BlobStream::new(&blob);
+        let mut stream = BlobStream::new(&blob).unwrap();
 
         let mut buf = vec![0; 2];
         let bytes_read = stream.read(&mut buf).unwrap();
@@ -176,7 +186,7 @@ mod tests {
     fn test_read_into_oversize_buffer() {
         let blob = blob_from_vec(vec![0, 1, 2, 3]);
 
-        let mut stream = BlobStream::new(&blob);
+        let mut stream = BlobStream::new(&blob).unwrap();
 
         let mut buf = vec![0; 6];
         let bytes_read = stream.read(&mut buf).unwrap();
@@ -189,7 +199,7 @@ mod tests {
     fn test_read_and_seek() {
         let blob = blob_from_vec(vec![0, 1, 2, 3]);
 
-        let mut stream = BlobStream::new(&blob);
+        let mut stream = BlobStream::new(&blob).unwrap();
 
         stream.seek(SeekFrom::Start(2)).unwrap();
         let mut buf = vec![0; 2];
@@ -214,7 +224,7 @@ mod tests {
     fn test_seek_past_end_and_read() {
         let blob = blob_from_vec(vec![0, 1, 2, 3]);
 
-        let mut stream = BlobStream::new(&blob);
+        let mut stream = BlobStream::new(&blob).unwrap();
 
         stream.seek(SeekFrom::Start(10)).unwrap();
         let mut buf = vec![0; 2];
@@ -226,11 +236,12 @@ mod tests {
 
     #[wasm_bindgen_test]
     fn test_crafted_png_seek_does_not_wrap() {
-        // A crafted PNG triggers seek(Current(0xFFFFFFE7)) from offset 41.
-        // On wasm32 with usize (32-bit), this wrapped to offset 16, causing an infinite loop.
-        // With u64 offsets the seek resolves to a large value past EOF and reads 0 bytes.
+        // Sanity-checks Cursor (Buffered path) for the large-Current-seek scenario.
+        // The historical 32-bit wrap/infinite-loop bug lived in the Lazy path;
+        // the Lazy-path regression guard is test_lazy_crafted_png_seek_does_not_wrap.
+        // A 41-byte blob is below BUFFER_THRESHOLD_BYTES, so BlobStream::new takes the Buffered path.
         let blob = blob_from_vec(vec![0u8; 41]);
-        let mut stream = BlobStream::new(&blob);
+        let mut stream = BlobStream::new(&blob).unwrap();
         stream.seek(SeekFrom::Start(41)).unwrap();
 
         // 0xFFFFFFE7 as i64 = 4294967271; 41 + 4294967271 = 4294967312 >> blob size
@@ -255,7 +266,7 @@ mod tests {
     /// Creates a BlobStream that always uses the Lazy strategy, regardless of blob size.
     fn lazy_stream(blob: &Blob) -> BlobStream {
         // threshold of 0 forces the Lazy path for any non-empty blob
-        BlobStream::new_with_threshold(blob, 0)
+        BlobStream::new_with_threshold(blob, 0).unwrap()
     }
 
     // Lazy-path equivalents of the Buffered tests
@@ -327,7 +338,7 @@ mod tests {
         let data = vec![42u8; 4];
         let blob = blob_from_vec(data.clone());
         // threshold == blob size => Buffered
-        let mut stream = BlobStream::new_with_threshold(&blob, 4);
+        let mut stream = BlobStream::new_with_threshold(&blob, 4).unwrap();
         assert!(matches!(stream.inner, StreamImpl::Buffered(_)));
 
         let mut buf = vec![0u8; 4];
@@ -341,11 +352,73 @@ mod tests {
         let data = vec![7u8; 5];
         let blob = blob_from_vec(data.clone());
         // threshold == blob size - 1 => Lazy
-        let mut stream = BlobStream::new_with_threshold(&blob, 4);
+        let mut stream = BlobStream::new_with_threshold(&blob, 4).unwrap();
         assert!(matches!(stream.inner, StreamImpl::Lazy { .. }));
 
         let mut buf = vec![0u8; 5];
         stream.read(&mut buf).unwrap();
         assert_eq!(buf, data);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_lazy_crafted_png_seek_does_not_wrap() {
+        // Same wrap scenario as test_crafted_png_seek_does_not_wrap but exercises the Lazy path.
+        let blob = blob_from_vec(vec![0u8; 41]);
+        let mut stream = lazy_stream(&blob);
+        stream.seek(SeekFrom::Start(41)).unwrap();
+
+        // 0xFFFFFFE7 as i64 = 4294967271; 41 + 4294967271 = 4294967312 >> blob size
+        let result = stream.seek(SeekFrom::Current(0xFFFF_FFE7_u32 as i64));
+        assert!(result.is_ok(), "seek past EOF must succeed");
+        assert!(result.unwrap() > 41, "offset must not have wrapped");
+
+        let mut buf = vec![0u8; 4];
+        let n = stream.read(&mut buf).unwrap();
+        assert_eq!(n, 0, "read past EOF must return 0 bytes");
+    }
+
+    #[wasm_bindgen_test]
+    fn test_buffered_seek_before_start() {
+        let blob = blob_from_vec(vec![0u8; 4]);
+        let mut stream = BlobStream::new(&blob).unwrap();
+
+        let result = stream.seek(SeekFrom::Current(-100));
+        assert!(result.is_err(), "seek before start must fail");
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_lazy_seek_before_start() {
+        let blob = blob_from_vec(vec![0u8; 4]);
+        let mut stream = lazy_stream(&blob);
+
+        let result = stream.seek(SeekFrom::Current(-100));
+        assert!(result.is_err(), "seek before start must fail");
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_lazy_seek_overflow_returns_invalid_input() {
+        // Asserts that overflow on Start(>i64::MAX) returns InvalidInput, not Other.
+        // Also documents the Buffered/Lazy asymmetry: Cursor accepts any u64 start position,
+        // while the Lazy path rejects values > i64::MAX.
+        let blob = blob_from_vec(vec![0u8; 4]);
+        let mut stream = lazy_stream(&blob);
+
+        let result = stream.seek(SeekFrom::Start(u64::MAX));
+        assert!(result.is_err(), "Start(u64::MAX) must fail on Lazy path");
+        assert_eq!(result.unwrap_err().kind(), std::io::ErrorKind::InvalidInput);
+    }
+
+    #[wasm_bindgen_test]
+    fn test_empty_blob_reads_zero_bytes() {
+        // read_entire_blob short-circuits on size == 0; new() must not error
+        let blob = blob_from_vec(vec![]);
+        let mut stream = BlobStream::new(&blob).unwrap();
+        assert!(matches!(stream.inner, StreamImpl::Buffered(_)));
+
+        let mut buf = vec![0u8; 4];
+        let n = stream.read(&mut buf).unwrap();
+        assert_eq!(n, 0, "read from empty blob must return 0 bytes");
     }
 }

--- a/packages/c2pa-wasm/src/wasm_builder.rs
+++ b/packages/c2pa-wasm/src/wasm_builder.rs
@@ -104,7 +104,7 @@ impl WasmBuilder {
         archive: &Blob,
         context_json: Option<String>,
     ) -> Result<WasmBuilder, JsString> {
-        let stream = BlobStream::new(archive);
+        let stream = BlobStream::new(archive).map_err(WasmError::other)?;
         let builder = if let Some(ctx_json) = context_json {
             let context = Context::new()
                 .with_settings(ctx_json.as_str())
@@ -180,7 +180,7 @@ impl WasmBuilder {
     /// Sets a thumbnail from a [`Blob`] to be included in the manifest. The thumbnail should represent the asset being signed.
     #[wasm_bindgen(js_name = setThumbnailFromBlob)]
     pub fn set_thumbnail_from_blob(&mut self, format: &str, blob: &Blob) -> Result<(), JsString> {
-        let mut stream = BlobStream::new(blob);
+        let mut stream = BlobStream::new(blob).map_err(WasmError::other)?;
         self.builder
             .set_thumbnail(format, &mut stream)
             .map_err(WasmError::from)?;
@@ -213,7 +213,7 @@ impl WasmBuilder {
         format: &str,
         blob: &Blob,
     ) -> Result<(), JsString> {
-        let mut stream = BlobStream::new(blob);
+        let mut stream = BlobStream::new(blob).map_err(WasmError::other)?;
         self.builder
             .add_ingredient_from_stream_async(json, format, &mut stream)
             .await
@@ -225,7 +225,7 @@ impl WasmBuilder {
     /// Add a [`Blob`] to the manifest as a resource. The ID must match an identifier in the manifest.
     #[wasm_bindgen(js_name = addResourceFromBlob)]
     pub fn add_resource_from_blob(&mut self, id: &str, blob: &Blob) -> Result<(), JsString> {
-        let mut stream = BlobStream::new(blob);
+        let mut stream = BlobStream::new(blob).map_err(WasmError::other)?;
         self.builder
             .add_resource(id, &mut stream)
             .map_err(WasmError::from)?;
@@ -305,7 +305,7 @@ impl WasmBuilder {
         dest: &mut Vec<u8>,
     ) -> Result<Vec<u8>, JsString> {
         let signer = WasmSigner::from_definition(signer_definition)?;
-        let mut stream = BlobStream::new(source);
+        let mut stream = BlobStream::new(source).map_err(WasmError::other)?;
 
         let mut cursor = Cursor::new(dest);
 

--- a/packages/c2pa-wasm/src/wasm_reader.rs
+++ b/packages/c2pa-wasm/src/wasm_reader.rs
@@ -40,7 +40,7 @@ impl WasmReader {
         blob: &Blob,
         context_json: Option<String>,
     ) -> Result<WasmReader, JsString> {
-        let stream = BlobStream::new(blob);
+        let stream = BlobStream::new(blob).map_err(WasmError::other)?;
         WasmReader::from_stream(format, stream, context_json).await
     }
 
@@ -75,8 +75,8 @@ impl WasmReader {
         fragment: &Blob,
         context_json: Option<String>,
     ) -> Result<WasmReader, JsString> {
-        let init_stream = BlobStream::new(init);
-        let fragment_stream = BlobStream::new(fragment);
+        let init_stream = BlobStream::new(init).map_err(WasmError::other)?;
+        let fragment_stream = BlobStream::new(fragment).map_err(WasmError::other)?;
 
         WasmReader::from_stream_fragment(format, init_stream, fragment_stream, context_json).await
     }

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -101,6 +101,12 @@ export interface VerifySettings {
    * Whether to verify the manifest after reading in the Reader. The default value is "true."
    */
   verifyAfterReading?: boolean;
+  /**
+   * Whether to fetch remote manifests when reading assets or adding ingredients.
+   * Only applicable when compiled with the `fetch_remote_manifests` feature.
+   * The default value is "true."
+   */
+  remoteManifestFetch?: boolean;
 }
 
 export interface BuilderSettings {

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -101,12 +101,6 @@ export interface VerifySettings {
    * Whether to verify the manifest after reading in the Reader. The default value is "true."
    */
   verifyAfterReading?: boolean;
-  /**
-   * Whether to fetch remote manifests when reading assets or adding ingredients.
-   * Only applicable when compiled with the `fetch_remote_manifests` feature.
-   * The default value is "true."
-   */
-  remoteManifestFetch?: boolean;
 }
 
 export interface BuilderSettings {


### PR DESCRIPTION
Fixes #93

PNG files with lots of chunks (AI-generated images from Microsoft Designer or Nano Banana 2, for example) were painfully slow to read. The original `BlobStream` called `Blob.slice()` + `FileReaderSync.readAsArrayBuffer()` on every single `read()`, crossing the JS/WASM boundary hundreds of times per file.

This introduces a dual-strategy `BlobStream`:

- Files under 50 MB are read into memory upfront in one shot, so subsequent `read()` calls just slice an `ArrayBuffer` with no JS/WASM crossing.
- Files 50 MB and over fall back to the original lazy per-read slice strategy to avoid doubling memory usage.

For typical files, JS/WASM crossings drop from O(N chunks) to O(1). PNG read times go from 8+ seconds to under a second for affected files.
