### PR TITLE
feat: Release c2pa-node as v0.6.0 from its new home in this monorepo

### DIFF
--- a/.changeset/huge-birds-behave.md
+++ b/.changeset/huge-birds-behave.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-node': minor
+---
+
+Release v0.6.0 from c2pa-node's new home in the c2pa-js monorepo.


### PR DESCRIPTION
Release c2pa-node as v0.6.0 from its new home in this monorepo. There are no actual changes in the code between this version release and the previous release v0.5.5.