### PR TITLE
fix: normalize object settings so trust/verify config isn't silently dropped

### DIFF
--- a/.changeset/fix-settings-object-serialization.md
+++ b/.changeset/fix-settings-object-serialization.md
@@ -1,0 +1,5 @@
+---
+"@contentauth/c2pa-node": patch
+---
+
+Fix settings objects being silently ignored by `Reader` and `Builder`. Object-form settings were serialized with `JSON.stringify`, which left camelCase keys (e.g. `verifyTrustList`, `trustAnchors`) in place — keys that c2pa-rs does not recognize and silently drops. They are now normalized with `settingsToJson` (camelCase → snake_case) via a shared `normalizeSettings` helper, so settings created with `createTrustSettings`/`createVerifySettings`/`mergeSettings` take effect when passed directly. String settings and already-snake_case objects are unaffected.

--- a/packages/c2pa-node/js-src/Builder.ts
+++ b/packages/c2pa-node/js-src/Builder.ts
@@ -19,6 +19,7 @@ import type {
 } from "@contentauth/c2pa-types";
 
 import { getNeonBinary } from "./binary.js";
+import { normalizeSettings } from "./Settings.js";
 import type {
   BuilderInterface,
   C2paSettings,
@@ -40,11 +41,7 @@ export class Builder implements BuilderInterface {
   constructor(private builder: NeonBuilderHandle) {}
 
   static new(settings?: C2paSettings): Builder {
-    const settingsStr = settings
-      ? typeof settings === "string"
-        ? settings
-        : JSON.stringify(settings)
-      : undefined;
+    const settingsStr = normalizeSettings(settings);
     const builder: NeonBuilderHandle = getNeonBinary().builderNew(settingsStr);
     return new Builder(builder);
   }
@@ -64,11 +61,7 @@ export class Builder implements BuilderInterface {
         "Failed to stringify JSON Manifest Definition: Unknown error",
       );
     }
-    const settingsStr = settings
-      ? typeof settings === "string"
-        ? settings
-        : JSON.stringify(settings)
-      : undefined;
+    const settingsStr = normalizeSettings(settings);
     const builder: NeonBuilderHandle = getNeonBinary().builderWithJson(
       jsonString,
       settingsStr,
@@ -145,11 +138,7 @@ export class Builder implements BuilderInterface {
     asset: SourceAsset,
     settings?: C2paSettings,
   ): Promise<Builder> {
-    const settingsStr = settings
-      ? typeof settings === "string"
-        ? settings
-        : JSON.stringify(settings)
-      : undefined;
+    const settingsStr = normalizeSettings(settings);
     return new Builder(
       await getNeonBinary().builderFromArchive(asset, settingsStr),
     );

--- a/packages/c2pa-node/js-src/Reader.ts
+++ b/packages/c2pa-node/js-src/Reader.ts
@@ -14,6 +14,7 @@
 import type { Manifest, ManifestStore } from "@contentauth/c2pa-types";
 
 import { getNeonBinary } from "./binary.js";
+import { normalizeSettings } from "./Settings.js";
 import type {
   C2paSettings,
   DestinationAsset,
@@ -43,7 +44,7 @@ export class Reader implements ReaderInterface {
   }
 
   static async fromAsset(asset: SourceAsset, settings?: C2paSettings): Promise<Reader | null> {
-    const settingsStr = settings ? (typeof settings === 'string' ? settings : JSON.stringify(settings)) : undefined;
+    const settingsStr = normalizeSettings(settings);
     const reader: NeonReaderHandle | null =
       await getNeonBinary().readerFromAsset(asset, settingsStr);
     return reader ? new Reader(reader) : null;
@@ -54,7 +55,7 @@ export class Reader implements ReaderInterface {
     asset: SourceAsset,
     settings?: C2paSettings,
   ): Promise<Reader> {
-    const settingsStr = settings ? (typeof settings === 'string' ? settings : JSON.stringify(settings)) : undefined;
+    const settingsStr = normalizeSettings(settings);
     const reader: NeonReaderHandle =
       await getNeonBinary().readerFromManifestDataAndAsset(manifestData, asset, settingsStr);
     return new Reader(reader);

--- a/packages/c2pa-node/js-src/Settings.spec.ts
+++ b/packages/c2pa-node/js-src/Settings.spec.ts
@@ -10,6 +10,7 @@ import {
   createVerifySettings,
   mergeSettings,
   settingsToJson,
+  normalizeSettings,
   loadSettingsFromFile,
   loadSettingsFromUrl,
 } from "./Settings.js";
@@ -320,6 +321,44 @@ verify_after_sign = false`;
       await expect(
         loadSettingsFromUrl("https://example.com/settings.json"),
       ).rejects.toThrow("Network error");
+    });
+  });
+
+  describe("normalizeSettings", () => {
+    it("returns undefined when no settings are provided", () => {
+      expect(normalizeSettings(undefined)).toBeUndefined();
+    });
+
+    it("passes a string through unchanged", () => {
+      const json = '{"verify":{"verify_trust":true}}';
+      expect(normalizeSettings(json)).toBe(json);
+    });
+
+    it("converts a camelCase settings object to snake_case JSON", () => {
+      // Regression: Reader/Builder previously used JSON.stringify directly,
+      // which left camelCase keys in place so c2pa-rs silently ignored them.
+      const settings = createTrustSettings({
+        verifyTrustList: true,
+        trustAnchors: "ANCHORS",
+      });
+
+      const result = normalizeSettings(settings);
+      expect(result).toBeDefined();
+      const parsed = JSON.parse(result as string);
+
+      expect(parsed.trust.verify_trust_list).toBe(true);
+      expect(parsed.trust.trust_anchors).toBe("ANCHORS");
+      // The camelCase keys must NOT survive.
+      expect(parsed.trust.verifyTrustList).toBeUndefined();
+      expect(parsed.trust.trustAnchors).toBeUndefined();
+    });
+
+    it("matches settingsToJson for object input", () => {
+      const settings = mergeSettings(
+        createTrustSettings({ verifyTrustList: true, trustAnchors: "A" }),
+        createVerifySettings({ verifyAfterReading: true, verifyTrust: true }),
+      );
+      expect(normalizeSettings(settings)).toBe(settingsToJson(settings));
     });
   });
 });

--- a/packages/c2pa-node/js-src/Settings.ts
+++ b/packages/c2pa-node/js-src/Settings.ts
@@ -14,7 +14,12 @@
 import * as fs from "fs-extra";
 import fetch from "node-fetch";
 
-import type { TrustConfig, VerifyConfig, SettingsContext } from "./types.d.ts";
+import type {
+  TrustConfig,
+  VerifyConfig,
+  SettingsContext,
+  C2paSettings,
+} from "./types.d.ts";
 
 type SettingsObjectType = {
   [k: string]: string | boolean | undefined | SettingsObjectType;
@@ -101,6 +106,28 @@ export function mergeSettings(...settings: SettingsContext[]): SettingsContext {
  */
 export function settingsToJson(settings: SettingsContext): string {
   return JSON.stringify(snakeCaseify(settings as SettingsObjectType));
+}
+
+/**
+ * Normalize a settings argument into the JSON string the native binding
+ * expects, or `undefined` when no settings were provided.
+ *
+ * A string is passed through unchanged. An object is converted with
+ * {@link settingsToJson} so that camelCase keys (as produced by
+ * {@link createTrustSettings}, {@link createVerifySettings}, {@link mergeSettings},
+ * etc.) are mapped to the snake_case keys c2pa-rs reads. Calling
+ * `JSON.stringify` on the object directly would leave camelCase keys in place,
+ * and the native layer silently ignores keys it does not recognize.
+ * @param settings A settings string or object, or undefined
+ * @returns The snake_case JSON string, or undefined
+ */
+export function normalizeSettings(
+  settings?: C2paSettings,
+): string | undefined {
+  if (!settings) return undefined;
+  return typeof settings === "string"
+    ? settings
+    : settingsToJson(settings as SettingsContext);
 }
 
 /**


### PR DESCRIPTION
## Problem

`Reader.fromAsset`, `Reader.fromManifestDataAndAsset`, and three `Builder` methods (`new`, `withJson`, `fromArchive`) serialize object-form `settings` with `JSON.stringify`. That leaves camelCase keys (e.g. `verifyTrustList`, `trustAnchors`) in place — keys that c2pa-rs does **not** recognize and silently drops.

The helper functions `createTrustSettings` / `createVerifySettings` / `mergeSettings` all produce camelCase objects, and their docstrings say the result "can be passed to `Reader`/`Builder`". In practice the settings have no effect unless the caller manually pre-converts them with `settingsToJson`. The failure is silent — e.g. trust verification appears configured but is quietly ignored.

## Fix

Add a shared `normalizeSettings(settings)` helper in `Settings.ts` and use it at all five call sites:

- A **string** is passed through unchanged.
- An **object** goes through `settingsToJson` (camelCase → snake_case), the same conversion callers would otherwise have to do by hand.

Backward-compatible: already-snake_case keys are idempotent under the converter, and string callers are unaffected. Adds regression tests to `Settings.spec.ts` asserting that camelCase keys are converted (and do **not** survive) and that `normalizeSettings` matches `settingsToJson` for object input.

## Validation

The change is a verbatim re-application of a patch previously validated against `c2pa-node-v2` @ 0.5.5 (`tsc -b` clean, `eslint` clean, Settings spec 21/21 passing), onto the now-migrated `packages/c2pa-node` copy of the same source. Runtime behavior was confirmed empirically: a camelCase settings object produced an *untrusted* result, while the equivalent `settingsToJson` string produced a *trusted* result — this PR makes the object form behave like the string form.