### PR TITLE
fix: sanitize manifestStore() output against __proto__ manifest labels

### DIFF
--- a/.changeset/twelve-frogs-drive.md
+++ b/.changeset/twelve-frogs-drive.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-web': patch
+---
+
+Sanitize manifest labels.

--- a/packages/c2pa-web/src/lib/worker.ts
+++ b/packages/c2pa-web/src/lib/worker.ts
@@ -17,6 +17,7 @@ import {
 } from '@contentauth/c2pa-wasm';
 import { createWorkerObjectMap } from './worker/workerObjectMap.js';
 import { createWorkerTx, rx } from './worker/rpc.js';
+import { sanitizeManifestStore } from './worker/sanitizeManifestStore.js';
 import { transfer } from 'highgain';
 
 const readerMap = createWorkerObjectMap<WasmReader>();
@@ -53,7 +54,7 @@ rx(
     },
     reader_manifestStore(readerId) {
       const reader = readerMap.get(readerId);
-      return reader.manifestStore();
+      return sanitizeManifestStore(reader.manifestStore());
     },
     reader_activeManifest(readerId) {
       const reader = readerMap.get(readerId);

--- a/packages/c2pa-web/src/lib/worker/sanitizeManifestStore.spec.ts
+++ b/packages/c2pa-web/src/lib/worker/sanitizeManifestStore.spec.ts
@@ -1,0 +1,68 @@
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { sanitizeManifestStore } from './sanitizeManifestStore.js';
+
+describe('sanitizeManifestStore', () => {
+  test('returns the store unchanged when store is nullish', () => {
+    expect(sanitizeManifestStore(null)).toBeNull();
+    expect(sanitizeManifestStore(undefined)).toBeUndefined();
+  });
+
+  test('rebuilds manifests as a null-prototype object for normal labels', () => {
+    const manifest = { title: 'test' };
+    const store = {
+      active_manifest: 'urn:c2pa:abc',
+      manifests: { 'urn:c2pa:abc': manifest }
+    };
+
+    const result = sanitizeManifestStore(store);
+
+    expect(Object.getPrototypeOf(result.manifests)).toBeNull();
+    expect(result.manifests['urn:c2pa:abc']).toBe(manifest);
+  });
+
+  test('recovers a manifest displaced into the prototype chain by a "__proto__" label', () => {
+    // Simulate what serde_wasm_bindgen produces when a HashMap key is "__proto__":
+    // bracket assignment triggers [[SetPrototypeOf]] instead of creating an own
+    // property, so the manifest ends up in the prototype chain and would be lost
+    // when postMessage structured-clones the object.
+    const manifest = { title: 'proto-manifest' };
+    const poisoned: Record<string, unknown> = {};
+    // eslint-disable-next-line no-proto
+    (poisoned as any).__proto__ = manifest;
+
+    // Confirm the poisoned state: no own property, but accessible via prototype.
+    expect(Object.hasOwn(poisoned, '__proto__')).toBe(false);
+    expect(Object.getPrototypeOf(poisoned)).toBe(manifest);
+
+    const store = { active_manifest: '__proto__', manifests: poisoned };
+    const result = sanitizeManifestStore(store);
+
+    // After sanitization the manifest must be an own property so it survives
+    // structured clone.
+    expect(Object.hasOwn(result.manifests, '__proto__')).toBe(true);
+    expect(result.manifests['__proto__']).toBe(manifest);
+  });
+
+  test('preserves sibling manifests alongside a recovered "__proto__" manifest', () => {
+    const activeManifest = { title: 'active' };
+    const siblingManifest = { title: 'sibling' };
+
+    const poisoned: Record<string, unknown> = { 'urn:c2pa:sibling': siblingManifest };
+    (poisoned as any).__proto__ = activeManifest;
+
+    const store = { active_manifest: '__proto__', manifests: poisoned };
+    const result = sanitizeManifestStore(store);
+
+    expect(result.manifests['__proto__']).toBe(activeManifest);
+    expect(result.manifests['urn:c2pa:sibling']).toBe(siblingManifest);
+  });
+});

--- a/packages/c2pa-web/src/lib/worker/sanitizeManifestStore.ts
+++ b/packages/c2pa-web/src/lib/worker/sanitizeManifestStore.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+
+/**
+ * Rebuilds the manifest store's manifests map as a null-prototype object so
+ * that reserved property names like "__proto__" are safe to use as keys.
+ *
+ * serde_wasm_bindgen uses bracket assignment when serializing HashMap entries.
+ * For the key "__proto__", `obj["__proto__"] = value` triggers [[SetPrototypeOf]]
+ * instead of creating an own property, putting that manifest in the prototype
+ * chain rather than the object itself. postMessage's structured clone only
+ * copies own properties, so it would disappear in transit. We detect this by
+ * checking whether the prototype was changed, and restore the manifest as an
+ * own property before the value leaves the worker.
+ */
+export function sanitizeManifestStore(store: any): any {
+  if (!store?.manifests) {
+    return store;
+  }
+
+  const rawManifests = store.manifests;
+  const sanitizedManifests = Object.assign(Object.create(null), rawManifests);
+
+  const proto = Object.getPrototypeOf(rawManifests);
+  if (proto !== null && proto !== Object.prototype && store.active_manifest) {
+    sanitizedManifests[store.active_manifest] = proto;
+  }
+
+  store.manifests = sanitizedManifests;
+  return store;
+}


### PR DESCRIPTION
`serde_wasm_bindgen` serializes Rust `HashMap` entries using bracket assignment (`obj[key] = value`). For the key `"__proto__"`, JavaScript intercepts this as `[[SetPrototypeOf]]` rather than creating an own property, so the manifest ends up in the prototype chain of the manifests object. When the worker returns the result over `postMessage`, structured clone only copies own properties, causing the manifest to silently disappear.

This PR adds a helper function `sanitizeManifestStore` which is used in the worker's `reader_manifestStore` handler. It rebuilds manifests as a null-prototype object (safe for arbitrary keys) and recovers any manifest displaced into the prototype chain before the value is structured-cloned.

Includes unit tests that directly construct the poisoned object state `serde_wasm_bindgen` would produce and verify the repair. Note: `c2pa-rs` itself rejects `__proto__` as a label through the normal builder API, so the fix is defense-in-depth against pre-existing signed assets from other tools or older library versions.