### PR TITLE
feat: Add retry logic when fetching trust anchors

### DIFF
--- a/.changeset/wet-coats-doubt.md
+++ b/.changeset/wet-coats-doubt.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-web': patch
+---
+
+Add retry with exponential backoff for fetching trust resources.

--- a/packages/c2pa-web/src/lib/settings.spec.ts
+++ b/packages/c2pa-web/src/lib/settings.spec.ts
@@ -278,6 +278,31 @@ describe('settings', () => {
         );
       });
 
+      test('should recover after a transient 500 by retrying', async ({
+        requestMock
+      }) => {
+        requestMock.use(
+          http.get(
+            'http://userAnchorsTransient500',
+            () => new HttpResponse(null, { status: 500 }),
+            { once: true }
+          ),
+          http.get('http://userAnchorsTransient500', () =>
+            HttpResponse.text(
+              '-----BEGIN CERTIFICATE-----baz-----END CERTIFICATE-----'
+            )
+          )
+        );
+
+        const result = await resolveSettings(undefined, {
+          trust: {
+            userAnchors: 'http://userAnchorsTransient500'
+          }
+        });
+
+        expect(result).toContain('BEGIN CERTIFICATE-----baz');
+      });
+
       test('should not fetch URLs for unknown keys not defined in TrustSettings', async ({
         requestMock
       }) => {

--- a/packages/c2pa-web/src/lib/settings.spec.ts
+++ b/packages/c2pa-web/src/lib/settings.spec.ts
@@ -9,7 +9,7 @@
 
 import { test, describe, expect } from 'test/methods.js';
 import { http, HttpResponse } from 'msw';
-import { resolveSettings, MAX_RESPONSE_SIZE } from './settings.js';
+import { resolveSettings, MAX_RESPONSE_SIZE, TRUST_MAX_RETRY_AFTER_MS } from './settings.js';
 
 describe('settings', () => {
   describe('resolveSettings', () => {
@@ -275,6 +275,60 @@ describe('settings', () => {
 
         await expect(resultPromise).rejects.toThrow(
           'Failed to fetch http://userAnchors429: 429'
+        );
+      });
+
+      test('should respect a reasonable Retry-After header and retry', async ({
+        requestMock
+      }) => {
+        let requestCount = 0;
+        requestMock.use(
+          http.get('http://userAnchorsRetryAfter', () => {
+            requestCount++;
+            if (requestCount === 1) {
+              return new HttpResponse(null, {
+                status: 429,
+                headers: { 'Retry-After': '1' }
+              });
+            }
+            return HttpResponse.text(
+              '-----BEGIN CERTIFICATE-----retryAfter-----END CERTIFICATE-----'
+            );
+          })
+        );
+
+        const result = await resolveSettings(undefined, {
+          trust: {
+            userAnchors: 'http://userAnchorsRetryAfter'
+          }
+        });
+
+        expect(result).toContain('BEGIN CERTIFICATE-----retryAfter');
+      });
+
+      test('should fail immediately when Retry-After exceeds the maximum allowed delay', async ({
+        requestMock
+      }) => {
+        const tooLongSeconds = TRUST_MAX_RETRY_AFTER_MS / 1000 + 1;
+        requestMock.use(
+          http.get(
+            'http://userAnchorsRetryAfterTooLong',
+            () =>
+              new HttpResponse(null, {
+                status: 429,
+                headers: { 'Retry-After': String(tooLongSeconds) }
+              })
+          )
+        );
+
+        const resultPromise = resolveSettings(undefined, {
+          trust: {
+            userAnchors: 'http://userAnchorsRetryAfterTooLong'
+          }
+        });
+
+        await expect(resultPromise).rejects.toThrow(
+          'exceeds the maximum allowed delay'
         );
       });
 

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -234,24 +234,47 @@ const containsCerts = (content: string): boolean =>
 
 const isUrl = (str: string): boolean => str.startsWith('http');
 
+const TRUST_FETCH_RETRIES = 2;
+const TRUST_INITIAL_RETRY_DELAY_MS = 200;
+const TRUST_MAX_RETRY_DELAY_MS = 2_000;
+
+function calculateBackoffMs(attempt: number): number {
+  const backoff = Math.min(
+    TRUST_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
+    TRUST_MAX_RETRY_DELAY_MS
+  );
+  return backoff + Math.floor(Math.random() * 200); // jitter
+}
+
 async function fetchResource(url: string): Promise<string> {
-  let res: Response;
-  try {
-    res = await fetch(url);
-  } catch (e) {
-    const message = e instanceof Error ? e.message : String(e);
-    throw new Error(`Network error fetching ${url}: ${message}`, { cause: e });
+  for (let attempt = 0; ; attempt++) {
+    let res: Response;
+    try {
+      res = await fetch(url);
+    } catch (e) {
+      if (attempt < TRUST_FETCH_RETRIES) {
+        await new Promise((resolve) => setTimeout(resolve, calculateBackoffMs(attempt)));
+        continue;
+      }
+      const message = e instanceof Error ? e.message : String(e);
+      throw new Error(`Network error fetching ${url}: ${message}`, { cause: e });
+    }
+
+    if (!res.ok) {
+      const retryable = res.status === 429 || res.status >= 500;
+      if (retryable && attempt < TRUST_FETCH_RETRIES) {
+        await new Promise((resolve) => setTimeout(resolve, calculateBackoffMs(attempt)));
+        continue;
+      }
+      throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+    }
+
+    const text = await res.text();
+
+    if (text.length > MAX_RESPONSE_SIZE) {
+      throw new Error(`Response from ${url} is too large. Max size is ${MAX_RESPONSE_SIZE} bytes.`);
+    }
+
+    return text;
   }
-
-  if (!res.ok) {
-    throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
-  }
-
-  const text = await res.text();
-
-  if (text.length > MAX_RESPONSE_SIZE) {
-    throw new Error(`Response from ${url} is too large. Max size is ${MAX_RESPONSE_SIZE} bytes.`);
-  }
-
-  return text;
 }

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -243,7 +243,8 @@ function calculateBackoffMs(attempt: number): number {
     TRUST_INITIAL_RETRY_DELAY_MS * 2 ** attempt,
     TRUST_MAX_RETRY_DELAY_MS
   );
-  return backoff + Math.floor(Math.random() * 200); // jitter
+  const jitter = Math.floor(Math.random() * 200);
+  return Math.min(backoff + jitter, TRUST_MAX_RETRY_DELAY_MS); // jitter, capped
 }
 
 async function fetchResource(url: string): Promise<string> {

--- a/packages/c2pa-web/src/lib/settings.ts
+++ b/packages/c2pa-web/src/lib/settings.ts
@@ -237,6 +237,7 @@ const isUrl = (str: string): boolean => str.startsWith('http');
 const TRUST_FETCH_RETRIES = 2;
 const TRUST_INITIAL_RETRY_DELAY_MS = 200;
 const TRUST_MAX_RETRY_DELAY_MS = 2_000;
+export const TRUST_MAX_RETRY_AFTER_MS = 30_000;
 
 function calculateBackoffMs(attempt: number): number {
   const backoff = Math.min(
@@ -245,6 +246,29 @@ function calculateBackoffMs(attempt: number): number {
   );
   const jitter = Math.floor(Math.random() * 200);
   return Math.min(backoff + jitter, TRUST_MAX_RETRY_DELAY_MS); // jitter, capped
+}
+
+/**
+ * Parses a `Retry-After` header value, which per HTTP spec is either a number of
+ * seconds or an HTTP date. Returns the delay in milliseconds, or null if the header
+ * is absent or unparseable.
+ */
+function parseRetryAfterMs(value: string | null): number | null {
+  if (!value) {
+    return null;
+  }
+
+  const seconds = Number(value);
+  if (!Number.isNaN(seconds)) {
+    return seconds * 1000;
+  }
+
+  const dateMs = Date.parse(value);
+  if (Number.isNaN(dateMs)) {
+    return null;
+  }
+
+  return dateMs - Date.now();
 }
 
 async function fetchResource(url: string): Promise<string> {
@@ -263,10 +287,34 @@ async function fetchResource(url: string): Promise<string> {
 
     if (!res.ok) {
       const retryable = res.status === 429 || res.status >= 500;
-      if (retryable && attempt < TRUST_FETCH_RETRIES) {
-        await new Promise((resolve) => setTimeout(resolve, calculateBackoffMs(attempt)));
-        continue;
+
+      if (retryable) {
+        if (res.status === 429) {
+          const retryAfterMs = parseRetryAfterMs(res.headers.get('retry-after'));
+          if (retryAfterMs !== null) {
+            if (retryAfterMs > TRUST_MAX_RETRY_AFTER_MS) {
+              throw new Error(
+                `Failed to fetch ${url}: server requested a Retry-After delay of ` +
+                  `${Math.ceil(retryAfterMs / 1000)}s, which exceeds the maximum allowed delay of ` +
+                  `${TRUST_MAX_RETRY_AFTER_MS / 1000}s`
+              );
+            }
+
+            if (attempt < TRUST_FETCH_RETRIES) {
+              await new Promise((resolve) => setTimeout(resolve, Math.max(retryAfterMs, 0)));
+              continue;
+            }
+
+            throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
+          }
+        }
+
+        if (attempt < TRUST_FETCH_RETRIES) {
+          await new Promise((resolve) => setTimeout(resolve, calculateBackoffMs(attempt)));
+          continue;
+        }
       }
+
       throw new Error(`Failed to fetch ${url}: ${res.status} ${res.statusText}`);
     }
 


### PR DESCRIPTION
This PR adds basic exponential backoff retry mechanism when fetching resources in `settings.ts`, which is used for retrieving trust resources. This is a localized retry solution for the short-term, which somewhat mirrors the logic that exists elsewhere in Node. We will revisit this later as part of the overall improvements to the JS SDKs to have a more shared retry mechanism for re-use across the SDKs.