### PR TITLE
feat: strip archive metadata assertion when constructing builder from archive

### DIFF
--- a/.changeset/small-keys-wait.md
+++ b/.changeset/small-keys-wait.md
@@ -1,0 +1,6 @@
+---
+'@contentauth/c2pa-node': minor
+'@contentauth/c2pa-wasm': minor
+---
+
+Strip archive metadata assertion when constructing builder from archive

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -619,6 +619,7 @@ dependencies = [
  "serde",
  "serde-wasm-bindgen",
  "serde_bytes",
+ "serde_json",
  "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/packages/c2pa-node/Cargo.toml
+++ b/packages/c2pa-node/Cargo.toml
@@ -30,7 +30,7 @@ reqwest = { version = "0.12.2", default-features = false, features = [
 ] }
 serde = { version = "1.0.203", features = ["derive"] }
 serde_bytes = "0.11.15"
-serde_json = "1.0.145"
+serde_json = "1.0.150"
 toml = "0.8"
 thiserror = "1.0.61"
 tokio = { version = "1.43.0", features = ["rt-multi-thread"] }

--- a/packages/c2pa-node/src/neon_builder.rs
+++ b/packages/c2pa-node/src/neon_builder.rs
@@ -324,11 +324,17 @@ impl NeonBuilder {
         let promise = cx
             .task(move || {
                 let source_stream = source.into_read_stream()?;
-                let builder = if let Some(context) = context_opt {
+                let mut builder = if let Some(context) = context_opt {
                     Builder::from_context(context).with_archive(source_stream)?
                 } else {
                     Builder::default().with_archive(source_stream)?
                 };
+                // The ARCHIVE_METADATA assertion is merely working-store bookkeeping
+                // used to reconstruct a builder from an archive.
+                builder
+                    .definition
+                    .assertions
+                    .retain(|a| a.label != c2pa::assertions::labels::ARCHIVE_METADATA);
                 Ok(builder)
             })
             .promise(

--- a/packages/c2pa-types/Cargo.toml
+++ b/packages/c2pa-types/Cargo.toml
@@ -7,4 +7,4 @@ rust-version.workspace = true
 [dependencies]
 c2pa = { workspace = true }
 schemars = "1.0.4"
-serde_json = "1.0.143"
+serde_json = "1.0.150"

--- a/packages/c2pa-wasm/Cargo.toml
+++ b/packages/c2pa-wasm/Cargo.toml
@@ -27,6 +27,7 @@ thiserror = "2.0.12"
 serde-wasm-bindgen = "0.6.5"
 serde = "1.0.219"
 serde_bytes = "0.11.19"
+serde_json = "1.0.150"
 
 # Enable the JS-backed randomness backend for both getrandom majors pulled in
 # transitively (0.3 via c2pa, 0.4 via lopdf/rand).

--- a/packages/c2pa-wasm/src/wasm_builder.rs
+++ b/packages/c2pa-wasm/src/wasm_builder.rs
@@ -105,7 +105,7 @@ impl WasmBuilder {
         context_json: Option<String>,
     ) -> Result<WasmBuilder, JsString> {
         let stream = BlobStream::new(archive).map_err(WasmError::other)?;
-        let builder = if let Some(ctx_json) = context_json {
+        let mut builder = if let Some(ctx_json) = context_json {
             let context = Context::new()
                 .with_settings(ctx_json.as_str())
                 .map_err(WasmError::from)?;
@@ -113,8 +113,15 @@ impl WasmBuilder {
                 .with_archive(stream)
                 .map_err(WasmError::from)?
         } else {
-            Builder::from_archive(stream).map_err(WasmError::from)?
+            Builder::default().with_archive(stream).map_err(WasmError::from)?
         };
+
+        // The ARCHIVE_METADATA assertion is merely working-store bookkeeping used to
+        // reconstruct a builder from an archive.
+        builder
+            .definition
+            .assertions
+            .retain(|a| a.label != c2pa::assertions::labels::ARCHIVE_METADATA);
 
         Ok(WasmBuilder::from_builder(builder))
     }

--- a/packages/c2pa-wasm/src/wasm_builder.rs
+++ b/packages/c2pa-wasm/src/wasm_builder.rs
@@ -145,6 +145,19 @@ impl WasmBuilder {
         Ok(())
     }
 
+    /// Add an assertion to the manifest under `label` with the given `data`.
+    #[wasm_bindgen(js_name = addAssertion)]
+    pub fn add_assertion(&mut self, label: String, data: JsValue) -> Result<(), JsString> {
+        let data: serde_json::Value =
+            serde_wasm_bindgen::from_value(data).map_err(WasmError::from)?;
+
+        self.builder
+            .add_assertion(&label, &data)
+            .map_err(WasmError::from)?;
+
+        Ok(())
+    }
+
     /// Add a redaction for a JUMBF URI with the given reason.
     ///
     /// Adds the URI to the builder's redaction list and appends a `c2pa.redacted` action

--- a/packages/c2pa-web/src/lib/builder.ts
+++ b/packages/c2pa-web/src/lib/builder.ts
@@ -73,6 +73,14 @@ export interface Builder {
   addAction: (action: Action) => Promise<void>;
 
   /**
+   * Add an assertion to the manifest under the given label.
+   *
+   * @param label The assertion label (reverse-domain format).
+   * @param data The assertion data (any JSON-serializable value).
+   */
+  addAssertion: (label: string, data: unknown) => Promise<void>;
+
+  /**
    * Sets the remote URL for a remote manifest. The manifest is expected to be available at this location.
    *
    * @param url URL pointing to the location the remote manifest will be stored.
@@ -303,6 +311,10 @@ function createBuilder(
 
     async addAction(action) {
       await tx.builder_addAction(id, action);
+    },
+
+    async addAssertion(label, data) {
+      await tx.builder_addAssertion(id, label, data);
     },
 
     async addRedaction(uri, reason) {

--- a/packages/c2pa-web/src/lib/worker.ts
+++ b/packages/c2pa-web/src/lib/worker.ts
@@ -101,6 +101,10 @@ rx(
       const builder = builderMap.get(builderId);
       builder.addAction(action);
     },
+    builder_addAssertion(builderId, label, data) {
+      const builder = builderMap.get(builderId);
+      builder.addAssertion(label, data);
+    },
     builder_addRedaction(builderId, uri, reason) {
       const builder = builderMap.get(builderId);
       builder.addRedaction(uri, reason);

--- a/packages/c2pa-web/src/lib/worker/rpc.ts
+++ b/packages/c2pa-web/src/lib/worker/rpc.ts
@@ -50,6 +50,11 @@ const { createTx, rx } = channel<{
   // Builder methods
   builder_setIntent: (builderId: number, intent: BuilderIntent) => void;
   builder_addAction: (builderId: number, action: Action) => void;
+  builder_addAssertion: (
+    builderId: number,
+    label: string,
+    data: unknown,
+  ) => void;
   builder_addRedaction: (builderId: number, uri: string, reason: C2paReason) => void;
   builder_filterActionsAt: (builderId: number, indices: number[]) => void;
   builder_filterIngredientsAt: (builderId: number, indices: number[]) => void;


### PR DESCRIPTION
This metadata is no longer useful or relevant once the builder has been constructed.