### PR TITLE
refactor: Consolidate `SigningAlg`, re-use existing `ManifestAssertionKind` definition, fix dependency list

### DIFF
--- a/.changeset/tame-otters-relax.md
+++ b/.changeset/tame-otters-relax.md
@@ -4,4 +4,4 @@
 '@contentauth/c2pa-utilities': minor
 ---
 
-Consolidate the `SigningAlg` type into `@contentauth/c2pa-utilities` (derived from `@contentauth/c2pa-types`'s schema-generated type) instead of hand-duplicating the algorithm list independently in `c2pa-web` and `c2pa-node`, and re-export `c2pa-node`'s `ManifestAssertionKind` from `@contentauth/c2pa-types` instead of a duplicate hand-written copy. Also fix `c2pa-node`'s `package.json` to list `@contentauth/c2pa-types` as a `dependency` rather than a `devDependency`, matching `c2pa-web`. No behavior change.
+Consolidate the `SigningAlg` type into `@contentauth/c2pa-utilities` (derived from `@contentauth/c2pa-types`'s schema-generated type). Re-use `ManifestAssertionKind` from `@contentauth/c2pa-types` instead of a duplicate hand-written copy. Fix `c2pa-node`'s `package.json` to list `@contentauth/c2pa-types` as a `dependency` rather than a `devDependency`, matching `c2pa-web`.

--- a/.changeset/tame-otters-relax.md
+++ b/.changeset/tame-otters-relax.md
@@ -1,0 +1,7 @@
+---
+'@contentauth/c2pa-node': patch
+'@contentauth/c2pa-web': patch
+'@contentauth/c2pa-utilities': minor
+---
+
+Consolidate the `SigningAlg` type into `@contentauth/c2pa-utilities` (derived from `@contentauth/c2pa-types`'s schema-generated type) instead of hand-duplicating the algorithm list independently in `c2pa-web` and `c2pa-node`, and re-export `c2pa-node`'s `ManifestAssertionKind` from `@contentauth/c2pa-types` instead of a duplicate hand-written copy. Also fix `c2pa-node`'s `package.json` to list `@contentauth/c2pa-types` as a `dependency` rather than a `devDependency`, matching `c2pa-web`. No behavior change.

--- a/packages/c2pa-node/js-src/types.d.ts
+++ b/packages/c2pa-node/js-src/types.d.ts
@@ -19,26 +19,18 @@ import type {
   C2paReason,
   Ingredient,
   Manifest,
+  ManifestAssertionKind,
   ManifestStore,
 } from "@contentauth/c2pa-types";
+import type { SigningAlg } from "@contentauth/c2pa-utilities";
 
-export type { Action, C2paReason, Ingredient } from "@contentauth/c2pa-types";
-
-/**
- * Describes the digital signature algorithms allowed by the C2PA spec
- *
- * Per <https://c2pa.org/specifications/specifications/1.0/specs/C2PA_Specification.html#_digital_signatures>:
- *
- * > All digital signatures that are stored in a C2PA Manifest shall > be generated using one of the digital signature algorithms and > key types listed as described in this section
- */
-export type SigningAlg =
-  | "es256"
-  | "es384"
-  | "es512"
-  | "ps256"
-  | "ps384"
-  | "ps512"
-  | "ed25519";
+export type {
+  Action,
+  C2paReason,
+  Ingredient,
+  ManifestAssertionKind,
+} from "@contentauth/c2pa-types";
+export type { SigningAlg } from "@contentauth/c2pa-utilities";
 
 export type ClaimVersion = 1 | 2;
 
@@ -63,8 +55,6 @@ export type TrustmarkVariant =
   | "P"
   // Quality Trustmark model
   | "Q";
-
-export type ManifestAssertionKind = "Cbor" | "Json" | "Binary" | "Uri";
 
 /**
  * A buffer for the source asset

--- a/packages/c2pa-node/package.json
+++ b/packages/c2pa-node/package.json
@@ -43,7 +43,6 @@
   "license": "MIT",
   "devDependencies": {
     "@changesets/cli": "^2.31.0",
-    "@contentauth/c2pa-types": "workspace:*",
     "@eslint/js": "^9.39.4",
     "@neon-rs/cli": "0.1.82",
     "@types/cli-progress": "^3.11.6",
@@ -75,6 +74,7 @@
   },
   "homepage": "https://github.com/contentauth/c2pa-js/tree/main/packages/c2pa-node#readme",
   "dependencies": {
+    "@contentauth/c2pa-types": "workspace:*",
     "@contentauth/c2pa-utilities": "workspace:*",
     "cargo-cp-artifact": "^0.1.9",
     "cli-progress": "^3.12.0",

--- a/packages/c2pa-utilities/package.json
+++ b/packages/c2pa-utilities/package.json
@@ -32,6 +32,7 @@
     }
   },
   "dependencies": {
+    "@contentauth/c2pa-types": "workspace:*",
     "ts-deepmerge": "^8.0.0"
   },
   "scripts": {

--- a/packages/c2pa-utilities/src/index.ts
+++ b/packages/c2pa-utilities/src/index.ts
@@ -10,3 +10,4 @@
 export * from './settings.js';
 export * from './fetchWithRetry.js';
 export * from './caseConversion.js';
+export * from './signingAlg.js';

--- a/packages/c2pa-utilities/src/signingAlg.ts
+++ b/packages/c2pa-utilities/src/signingAlg.ts
@@ -10,12 +10,12 @@
 import type { SigningAlg as SchemaSigningAlg } from '@contentauth/c2pa-types';
 
 /**
- * The digital signature algorithms allowed by the C2PA spec, as accepted/produced by `c2pa-rs`
- * at the signer construction boundary (`Signer.alg`, `LocalSigner`/`CallbackSigner` config, etc).
+ * The digital signature algorithms allowed by the C2PA spec, as accepted/produced by the core
+ * native library at the signer construction boundary.
  *
- * `c2pa-rs` deserializes and displays this value as lowercase here, which is distinct from the
+ * The native library deserializes and displays this value as lowercase here, which is distinct from the
  * PascalCase casing it serializes into manifests (see `SigningAlg` from `@contentauth/c2pa-types`,
- * used for `SignatureInfo.alg` when reading manifests) — hence this is derived from that schema
+ * used for `SignatureInfo.alg` when reading manifests). This is therefore derived from that schema
  * type rather than being identical to it.
  */
 export type SigningAlg = Lowercase<SchemaSigningAlg>;

--- a/packages/c2pa-utilities/src/signingAlg.ts
+++ b/packages/c2pa-utilities/src/signingAlg.ts
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+
+import type { SigningAlg as SchemaSigningAlg } from '@contentauth/c2pa-types';
+
+/**
+ * The digital signature algorithms allowed by the C2PA spec, as accepted/produced by `c2pa-rs`
+ * at the signer construction boundary (`Signer.alg`, `LocalSigner`/`CallbackSigner` config, etc).
+ *
+ * `c2pa-rs` deserializes and displays this value as lowercase here, which is distinct from the
+ * PascalCase casing it serializes into manifests (see `SigningAlg` from `@contentauth/c2pa-types`,
+ * used for `SignatureInfo.alg` when reading manifests) — hence this is derived from that schema
+ * type rather than being identical to it.
+ */
+export type SigningAlg = Lowercase<SchemaSigningAlg>;

--- a/packages/c2pa-utilities/tsconfig.json
+++ b/packages/c2pa-utilities/tsconfig.json
@@ -4,6 +4,9 @@
   "include": [],
   "references": [
     {
+      "path": "../c2pa-types"
+    },
+    {
       "path": "./tsconfig.lib.json"
     },
     {

--- a/packages/c2pa-utilities/tsconfig.lib.json
+++ b/packages/c2pa-utilities/tsconfig.lib.json
@@ -10,6 +10,11 @@
     "lib": ["ES2023", "DOM"]
   },
   "include": ["src/**/*.ts"],
+  "references": [
+    {
+      "path": "../c2pa-types"
+    }
+  ],
   "exclude": [
     "vitest.config.ts",
     "vitest.config.mts",

--- a/packages/c2pa-web/src/lib/signer.ts
+++ b/packages/c2pa-web/src/lib/signer.ts
@@ -7,14 +7,9 @@
  * it.
  */
 
-export type SigningAlg =
-  | 'es256'
-  | 'es384'
-  | 'es512'
-  | 'ps256'
-  | 'ps384'
-  | 'ps512'
-  | 'ed25519';
+import type { SigningAlg } from '@contentauth/c2pa-utilities';
+
+export type { SigningAlg };
 
 export interface Signer {
   sign: (

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -107,6 +107,9 @@ importers:
 
   packages/c2pa-node:
     dependencies:
+      '@contentauth/c2pa-types':
+        specifier: workspace:*
+        version: link:../c2pa-types
       '@contentauth/c2pa-utilities':
         specifier: workspace:*
         version: link:../c2pa-utilities
@@ -141,9 +144,6 @@ importers:
       '@changesets/cli':
         specifier: ^2.31.0
         version: 2.31.0(@types/node@22.19.20)
-      '@contentauth/c2pa-types':
-        specifier: workspace:*
-        version: link:../c2pa-types
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
@@ -225,6 +225,9 @@ importers:
 
   packages/c2pa-utilities:
     dependencies:
+      '@contentauth/c2pa-types':
+        specifier: workspace:*
+        version: link:../c2pa-types
       ts-deepmerge:
         specifier: ^8.0.0
         version: 8.0.0


### PR DESCRIPTION
Small cleanup items:

- Consolidate `SigningAlg` into a single shared type in `c2pa-utilities`, now imported and used by both `c2pa-web` and `c2pa-node`. See new `signingAlg.ts` in `c2pa-utilities`.
- `ManifestAssertionKind` was duplicated in `c2pa-node`; updated to use the type already defined in `c2pa-types`.
- Moved `@contentauth/c2pa-types` from `devDependencies` to `dependencies` in `c2pa-node`'s`package.json`.