### PR TITLE
chore: Upgrade c2pa to version 0.90.4

### DIFF
--- a/.changeset/lemon-planes-relax.md
+++ b/.changeset/lemon-planes-relax.md
@@ -1,0 +1,8 @@
+---
+'@contentauth/c2pa-node': patch
+'@contentauth/c2pa-types': patch
+'@contentauth/c2pa-wasm': patch
+'@contentauth/c2pa-web': patch
+---
+
+Update c2pa to 0.90.4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-c2pa = { version = "=0.90.1", features = ["experimental_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
+c2pa = { version = "=0.90.4", features = ["unstable_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
Following stable release v0.90.4 from https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-v0.90.4