### PR TITLE
feat: incorporate c2pa builder `filter_actions_and_ingredients`

### DIFF
--- a/.changeset/common-rice-love.md
+++ b/.changeset/common-rice-love.md
@@ -1,0 +1,7 @@
+---
+'@contentauth/c2pa-node': patch
+'@contentauth/c2pa-wasm': patch
+'@contentauth/c2pa-web': patch
+---
+
+feat: incorporate c2pa builder filter_actions_and_ingredients

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "c2pa"
-version = "0.90.1"
+version = "0.90.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f8d204fef7d3eeca6b3265148790ba0b0e847b27cfd19a0c88936240c1ec1af"
+checksum = "96ada3379bed665e87de66966901fb7d476efd28985b038378cba9faa2c84199"
 dependencies = [
  "asn1-rs",
  "async-generic",
@@ -520,7 +520,6 @@ dependencies = [
  "log",
  "lopdf",
  "memchr",
- "mp4",
  "nom 7.1.3",
  "non-empty-string",
  "nonempty-collections",
@@ -1827,9 +1826,9 @@ checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "id3"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70d6d9f23a28c6feab60d7b4a339e004809019ec9d5fd964b3f4c655ff9bc141"
+checksum = "24993fcabcbc07c8ac076a8e62db8593d1a5c4dbe81d57e531d2b7cb7f737380"
 dependencies = [
  "bitflags",
  "byteorder",
@@ -2335,20 +2334,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "mp4"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9ef834d5ed55e494a2ae350220314dc4aacd1c43a9498b00e320e0ea352a5c3"
-dependencies = [
- "byteorder",
- "bytes",
- "num-rational",
- "serde",
- "serde_json",
- "thiserror 1.0.69",
-]
-
-[[package]]
 name = "ndarray"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2566,7 +2551,6 @@ dependencies = [
  "num-bigint",
  "num-integer",
  "num-traits",
- "serde",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-c2pa = { version = "=0.90.1", features = ["experimental_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
+c2pa = { version = "=0.90.4", features = ["unstable_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
 
 [profile.release]
 opt-level = "s"

--- a/packages/c2pa-node/js-src/Builder.spec.ts
+++ b/packages/c2pa-node/js-src/Builder.spec.ts
@@ -1142,9 +1142,9 @@ describe("Builder", () => {
 
       builder.addIngredient(
         JSON.stringify({
-          title: "ai-ingredient",
+          title: "my-ingredient",
           format: "image/jpeg",
-          instance_id: "ai-1",
+          instance_id: "my-1",
           relationship: "inputTo",
         }),
       );
@@ -1153,7 +1153,7 @@ describe("Builder", () => {
       // would rescue the ingredient. filterActionsAndIngredients keeps both together.
       builder.filterActionsAndIngredients(
         (action) => action.action !== "c2pa.edited",
-        (ingredient) => (ingredient as any).instance_id === "ai-1",
+        (ingredient) => (ingredient as any).instance_id === "my-1",
       );
 
       const definition = builder.getManifestDefinition();

--- a/packages/c2pa-node/js-src/Builder.spec.ts
+++ b/packages/c2pa-node/js-src/Builder.spec.ts
@@ -1131,7 +1131,7 @@ describe("Builder", () => {
                 },
                 {
                   action: "c2pa.edited",
-                  parameters: { ingredientIds: ["ai-1"] },
+                  parameters: { ingredientIds: ["my-1"] },
                 },
               ],
             },

--- a/packages/c2pa-node/js-src/Builder.spec.ts
+++ b/packages/c2pa-node/js-src/Builder.spec.ts
@@ -180,6 +180,7 @@ describe("Builder", () => {
     beforeEach(() => {
       builder = Builder.withJson(manifestDefinition);
       builder.updateManifestProperty("claim_version", 2);
+      builder.setIntent("edit");
     });
 
     beforeEach(async () => {
@@ -602,6 +603,9 @@ describe("Builder", () => {
         instance_id: "thumb-step1-1234",
         thumbnail: { format: "image/jpeg", identifier: "thumbnail.jpg" },
       });
+      step1Builder.setIntent({
+        create: "http://c2pa.org/digitalsourcetype/empty",
+      });
       await step1Builder.addResource("thumbnail.jpg", {
         mimeType: "image/jpeg",
         buffer: testThumbnail,
@@ -681,6 +685,9 @@ describe("Builder", () => {
             data: { keep: true },
           },
         ],
+      });
+      step1Builder.setIntent({
+        create: "http://c2pa.org/digitalsourcetype/empty",
       });
       const step1Dest = { buffer: null };
       await step1Builder.signAsync(signer, source, step1Dest);
@@ -835,6 +842,7 @@ describe("Builder", () => {
       };
 
       const builder = Builder.withJson(simpleManifestDefinition);
+      builder.setIntent({ create: "http://c2pa.org/digitalsourcetype/empty" });
 
       // Add an action using addAction method
       // The action needs to be a structured object matching the c2pa Action type
@@ -929,7 +937,7 @@ describe("Builder", () => {
 
     it("should add ingredient from reader", async () => {
       const builder1 = Builder.new();
-      builder1.setIntent("edit" as any);
+      builder1.setIntent("edit");
       const signer = LocalSigner.newSigner(publicKey, privateKey, "es256");
       const dest1: DestinationBufferAsset = {
         buffer: null,
@@ -945,6 +953,7 @@ describe("Builder", () => {
 
       // Create a new builder and add ingredient from the reader
       const builder2 = Builder.new();
+      builder2.setIntent("edit");
       const ingredient = builder2.addIngredientFromReader(reader!);
       expect(ingredient).toBeDefined();
 
@@ -1103,6 +1112,102 @@ describe("Builder", () => {
           throw new Error("ingredient boom");
         }),
       ).toThrow("ingredient boom");
+    });
+
+    it("filterActionsAndIngredients rescues an edited action for a kept ingredient", () => {
+      const builder = Builder.withJson({
+        claim_generator_info: [{ name: "c2pa_test", version: "1.0.0" }],
+        title: "Test_FilterActionsAndIngredients",
+        format: "image/jpeg",
+        ingredients: [],
+        assertions: [
+          {
+            label: "c2pa.actions",
+            data: {
+              actions: [
+                {
+                  action: "c2pa.created",
+                  digitalSourceType: "http://c2pa.org/digitalsourcetype/empty",
+                },
+                {
+                  action: "c2pa.edited",
+                  parameters: { ingredientIds: ["ai-1"] },
+                },
+              ],
+            },
+          },
+        ],
+        resources: { resources: {} },
+      });
+
+      builder.addIngredient(
+        JSON.stringify({
+          title: "ai-ingredient",
+          format: "image/jpeg",
+          instance_id: "ai-1",
+          relationship: "inputTo",
+        }),
+      );
+
+      // The action predicate alone would drop c2pa.edited; the ingredient predicate alone
+      // would rescue the ingredient. filterActionsAndIngredients keeps both together.
+      builder.filterActionsAndIngredients(
+        (action) => action.action !== "c2pa.edited",
+        (ingredient) => (ingredient as any).instance_id === "ai-1",
+      );
+
+      const definition = builder.getManifestDefinition();
+      const actionsAssertion = definition.assertions!.find((a) =>
+        a.label.startsWith("c2pa.actions"),
+      );
+      const names = (actionsAssertion!.data as any).actions.map(
+        (a: any) => a.action,
+      );
+      expect(names).toContain("c2pa.created");
+      expect(names).toContain("c2pa.edited");
+      expect(definition.ingredients ?? []).toHaveLength(1);
+    });
+
+    it("filterActionsAndIngredients drops unreferenced and unrescued", () => {
+      const builder = Builder.withJson(actionsManifest());
+
+      builder.addIngredient(
+        JSON.stringify({
+          title: "orphan",
+          format: "image/jpeg",
+          instance_id: "orphan-1",
+          relationship: "componentOf",
+        }),
+      );
+
+      builder.filterActionsAndIngredients(
+        (action) => action.action === "c2pa.edited",
+        () => false,
+      );
+
+      const definition = builder.getManifestDefinition();
+      const actionsAssertion = definition.assertions!.find((a) =>
+        a.label.startsWith("c2pa.actions"),
+      );
+      const names = (actionsAssertion!.data as any).actions.map(
+        (a: any) => a.action,
+      );
+      expect(names).toContain("c2pa.created");
+      expect(names).toContain("c2pa.edited");
+      expect(names).not.toContain("c2pa.color_adjustments");
+      expect(definition.ingredients ?? []).toHaveLength(0);
+    });
+
+    it("filterActionsAndIngredients surfaces an error thrown by either predicate", () => {
+      const builder = Builder.withJson(actionsManifest());
+      expect(() =>
+        builder.filterActionsAndIngredients(
+          () => {
+            throw new Error("action predicate boom");
+          },
+          () => false,
+        ),
+      ).toThrow("action predicate boom");
     });
   });
 });

--- a/packages/c2pa-node/js-src/Builder.ts
+++ b/packages/c2pa-node/js-src/Builder.ts
@@ -279,6 +279,20 @@ export class Builder implements BuilderInterface {
     getNeonBinary().builderFilterIngredients.call(this.builder, rescue);
   }
 
+  filterActionsAndIngredients(
+    keepAction: (action: Action) => boolean,
+    rescueIngredient: (
+      ingredient: Ingredient,
+      provenance: ManifestStore | null,
+    ) => boolean,
+  ): void {
+    getNeonBinary().builderFilterActionsAndIngredients.call(
+      this.builder,
+      keepAction,
+      rescueIngredient,
+    );
+  }
+
   getHandle(): NeonBuilderHandle {
     return this.builder;
   }

--- a/packages/c2pa-node/js-src/IdentityAssertion.spec.ts
+++ b/packages/c2pa-node/js-src/IdentityAssertion.spec.ts
@@ -84,10 +84,8 @@ describe("IdentityAssertionBuilder", () => {
           actions: [
             {
               action: "c2pa.created",
-              parameters: {
-                digitalSourceType:
-                  "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCapture",
-              },
+              digitalSourceType:
+                "http://cv.iptc.org/newscodes/digitalsourcetype/digitalCapture",
             },
           ],
         } as any,

--- a/packages/c2pa-node/js-src/Signer.spec.ts
+++ b/packages/c2pa-node/js-src/Signer.spec.ts
@@ -147,6 +147,7 @@ describe("CallbackSigner", () => {
     };
 
     const builder = Builder.withJson(manifestDefinition);
+    builder.setIntent({ create: "http://c2pa.org/digitalsourcetype/empty" });
     const source = {
       buffer: await fs.readFile("./tests/fixtures/CA.jpg"),
       mimeType: "image/jpeg",

--- a/packages/c2pa-node/js-src/types.d.ts
+++ b/packages/c2pa-node/js-src/types.d.ts
@@ -381,6 +381,25 @@ export interface BuilderInterface {
   ): void;
 
   /**
+   * Experimental.
+   * Retains actions and ingredients together.
+   *
+   * `rescueIngredient` is evaluated for every ingredient first; any action referencing an
+   * ingredient it would rescue is force-kept regardless of `keepAction`.
+   *
+   * @param keepAction The action is retained when the predicate returns true.
+   * @param rescueIngredient Can rescue an otherwise-orphaned ingredient and the action
+   * referencing it by returning true.
+   */
+  filterActionsAndIngredients(
+    keepAction: (action: Action) => boolean,
+    rescueIngredient: (
+      ingredient: Ingredient,
+      provenance: ManifestStore | null,
+    ) => boolean,
+  ): void;
+
+  /**
    * Get the internal handle for use with Neon bindings
    */
   getHandle(): NeonBuilderHandle;

--- a/packages/c2pa-node/src/lib.rs
+++ b/packages/c2pa-node/src/lib.rs
@@ -93,6 +93,10 @@ fn main(mut cx: ModuleContext) -> NeonResult<()> {
         "builderFilterIngredients",
         neon_builder::NeonBuilder::filter_ingredients,
     )?;
+    cx.export_function(
+        "builderFilterActionsAndIngredients",
+        neon_builder::NeonBuilder::filter_actions_and_ingredients,
+    )?;
 
     // Reader
     cx.export_function("readerNew", neon_reader::NeonReader::new)?;

--- a/packages/c2pa-node/src/neon_builder.rs
+++ b/packages/c2pa-node/src/neon_builder.rs
@@ -739,6 +739,100 @@ impl NeonBuilder {
         Ok(cx.undefined())
     }
 
+    /// Retains actions and ingredients together in one step, per
+    /// `Builder::filter_actions_and_ingredients`.
+    ///
+    /// `rescue_ingredient` is evaluated for every ingredient first; any action referencing an
+    /// ingredient it would rescue is force-kept regardless of `keep_action`.
+    ///
+    /// If either predicate throws or returns a non-boolean, the exception is surfaced to the
+    /// caller. As with [`Self::filter_actions`], the builder may be left partially filtered when a
+    /// predicate throws midway; callers should discard it on error.
+    ///
+    /// # Deadlock
+    /// As with [`Self::filter_actions`], the builder's lock is held for the whole call, so neither
+    /// predicate must call back into the same builder; doing so would deadlock.
+    pub fn filter_actions_and_ingredients(cx: FunctionContext) -> JsResult<JsUndefined> {
+        let rt = runtime();
+        // `cx` and `pending` are each borrowed mutably from one closure at a time, never by both
+        // closures simultaneously (calls into `filter_actions_and_ingredients` are synchronous and
+        // sequential), so `RefCell` lets both `FnMut` closures below share access without a
+        // conflicting double mutable borrow of `cx`/`pending` themselves.
+        let cx_cell = std::cell::RefCell::new(cx);
+        let pending: std::cell::RefCell<Option<neon::result::Throw>> =
+            std::cell::RefCell::new(None);
+
+        let (this, keep_action, rescue_ingredient, undefined) = {
+            let mut cx = cx_cell.borrow_mut();
+            let this = cx.this::<JsBox<Self>>()?;
+            let keep_action = cx.argument::<JsFunction>(0)?;
+            let rescue_ingredient = cx.argument::<JsFunction>(1)?;
+            let undefined = cx.undefined();
+            (this, keep_action, rescue_ingredient, undefined)
+        };
+        let mut builder = rt.block_on(async { this.builder.lock().await });
+
+        // See `filter_actions`/`filter_ingredients`: capture a JS exception out-of-band and
+        // re-raise it afterwards, short-circuiting once a throw is pending.
+        let filter_result = builder
+            .filter_actions_and_ingredients(
+                |action| {
+                    if pending.borrow().is_some() {
+                        return false;
+                    }
+                    let mut cx = cx_cell.borrow_mut();
+                    let js_action = match neon_serde4::to_value(&mut *cx, action) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            *pending.borrow_mut() = cx.throw_error::<_, ()>(e.to_string()).err();
+                            return false;
+                        }
+                    };
+                    match callback_returns_true(&mut cx, &keep_action, undefined, js_action) {
+                        Ok(keep) => keep,
+                        Err(throw) => {
+                            *pending.borrow_mut() = Some(throw);
+                            false
+                        }
+                    }
+                },
+                |ingredient| {
+                    if pending.borrow().is_some() {
+                        return false;
+                    }
+                    let mut cx = cx_cell.borrow_mut();
+                    let js_ingredient = match neon_serde4::to_value(&mut *cx, ingredient) {
+                        Ok(v) => v,
+                        Err(e) => {
+                            *pending.borrow_mut() = cx.throw_error::<_, ()>(e.to_string()).err();
+                            return false;
+                        }
+                    };
+                    let js_provenance = ingredient_provenance_value(&mut cx, ingredient);
+                    match callback_returns_true_with(
+                        &mut cx,
+                        &rescue_ingredient,
+                        undefined,
+                        &[js_ingredient, js_provenance],
+                    ) {
+                        Ok(rescue) => rescue,
+                        Err(throw) => {
+                            *pending.borrow_mut() = Some(throw);
+                            false
+                        }
+                    }
+                },
+            )
+            .map(|_| ());
+
+        let mut cx = cx_cell.into_inner();
+        if let Some(throw) = pending.into_inner() {
+            return Err(throw);
+        }
+        filter_result.or_else(|err| cx.throw_error(err.to_string()))?;
+        Ok(cx.undefined())
+    }
+
     /// Update a manifest property. Available properties are limited to strings and numbers.
     /// There are other methods for thumbnails, ingredients and assertions, etc.
     pub fn update_manifest_property(mut cx: FunctionContext) -> JsResult<JsUndefined> {

--- a/packages/c2pa-wasm/src/wasm_builder.rs
+++ b/packages/c2pa-wasm/src/wasm_builder.rs
@@ -237,7 +237,7 @@ impl WasmBuilder {
     /// `rescue_ingredient` (driven by `ingredient_indices`) is evaluated for every ingredient
     /// first; any action referencing an ingredient it would rescue is force-kept regardless of
     /// `keep_action`.
-    /// #[wasm_bindgen(js_name = filterActionsAndIngredientsAt)]
+    #[wasm_bindgen(js_name = filterActionsAndIngredientsAt)]
     pub fn filter_actions_and_ingredients_at(
         &mut self,
         action_indices: Vec<u32>,

--- a/packages/c2pa-wasm/src/wasm_builder.rs
+++ b/packages/c2pa-wasm/src/wasm_builder.rs
@@ -53,14 +53,13 @@ impl WasmBuilder {
     /// Optionally accepts a context JSON string to configure the builder.
     #[wasm_bindgen(js_name = new)]
     pub fn new(context_json: Option<String>) -> Result<WasmBuilder, JsString> {
-        let builder = if let Some(json) = context_json {
-            let context = Context::new()
+        let context = match context_json {
+            Some(json) => Context::new()
                 .with_settings(json.as_str())
-                .map_err(WasmError::from)?;
-            Builder::from_context(context)
-        } else {
-            Builder::new()
+                .map_err(WasmError::from)?,
+            None => Context::new(),
         };
+        let builder = Builder::from_context(context);
 
         Ok(WasmBuilder::from_builder(builder))
     }
@@ -79,20 +78,15 @@ impl WasmBuilder {
     /// Optionally accepts a context JSON string to configure the builder.
     #[wasm_bindgen(js_name = fromJson)]
     pub fn from_json(json: &str, context_json: Option<String>) -> Result<WasmBuilder, JsString> {
-        let builder = if let Some(ctx_json) = context_json {
-            let context = Context::new()
+        let context = match context_json {
+            Some(ctx_json) => Context::new()
                 .with_settings(ctx_json.as_str())
-                .map_err(WasmError::from)?;
-            let mut builder = Builder::from_context(context);
-            // Parse the manifest definition and set it directly
-            let definition = Builder::from_json(json)
-                .map_err(WasmError::from)?
-                .definition;
-            builder.definition = definition;
-            builder
-        } else {
-            Builder::from_json(json).map_err(WasmError::from)?
+                .map_err(WasmError::from)?,
+            None => Context::new(),
         };
+        let builder = Builder::from_context(context)
+            .with_definition(json)
+            .map_err(WasmError::from)?;
 
         Ok(WasmBuilder::from_builder(builder))
     }
@@ -230,6 +224,46 @@ impl WasmBuilder {
                 i += 1;
                 rescue
             })
+            .map_err(WasmError::from)?;
+
+        Ok(())
+    }
+
+    /// Retains actions and ingredients together in one step, per
+    /// `Builder::filter_actions_and_ingredients`. `action_indices`/`ingredient_indices` are
+    /// 0-based indices into [`Self::get_definition`]'s `c2pa.actions` assertion / `ingredients`
+    /// array, resolved on the JS side for the same reason as [`Self::filter_actions_at`].
+    ///
+    /// `rescue_ingredient` (driven by `ingredient_indices`) is evaluated for every ingredient
+    /// first; any action referencing an ingredient it would rescue is force-kept regardless of
+    /// `keep_action`.
+    /// #[wasm_bindgen(js_name = filterActionsAndIngredientsAt)]
+    pub fn filter_actions_and_ingredients_at(
+        &mut self,
+        action_indices: Vec<u32>,
+        ingredient_indices: Vec<u32>,
+    ) -> Result<(), JsString> {
+        let action_indices: std::collections::HashSet<u32> = action_indices.into_iter().collect();
+        let ingredient_indices: std::collections::HashSet<u32> =
+            ingredient_indices.into_iter().collect();
+        // See `filter_actions_at`: `usize` cannot overflow for an in-memory action/ingredient
+        // count.
+        let mut action_i: usize = 0;
+        let mut ingredient_i: usize = 0;
+        self.builder
+            .filter_actions_and_ingredients(
+                |_action| {
+                    let keep = u32::try_from(action_i).is_ok_and(|idx| action_indices.contains(&idx));
+                    action_i += 1;
+                    keep
+                },
+                |_ingredient| {
+                    let rescue = u32::try_from(ingredient_i)
+                        .is_ok_and(|idx| ingredient_indices.contains(&idx));
+                    ingredient_i += 1;
+                    rescue
+                },
+            )
             .map_err(WasmError::from)?;
 
         Ok(())

--- a/packages/c2pa-wasm/src/wasm_reader.rs
+++ b/packages/c2pa-wasm/src/wasm_reader.rs
@@ -49,19 +49,16 @@ impl WasmReader {
         stream: impl Read + Seek + Send,
         context_json: Option<String>,
     ) -> Result<WasmReader, JsString> {
-        let reader = if let Some(json) = context_json {
-            let context = Context::new()
+        let context = match context_json {
+            Some(json) => Context::new()
                 .with_settings(json.as_str())
-                .map_err(WasmError::from)?;
-            Reader::from_context(context)
-                .with_stream_async(format, stream)
-                .await
-                .map_err(WasmError::from)?
-        } else {
-            Reader::from_stream_async(format, stream)
-                .await
-                .map_err(WasmError::from)?
+                .map_err(WasmError::from)?,
+            None => Context::new(),
         };
+        let reader = Reader::from_context(context)
+            .with_stream_async(format, stream)
+            .await
+            .map_err(WasmError::from)?;
 
         Ok(WasmReader::from_reader(reader).await)
     }
@@ -87,19 +84,16 @@ impl WasmReader {
         fragment: impl Read + Seek + Send,
         context_json: Option<String>,
     ) -> Result<WasmReader, JsString> {
-        let reader = if let Some(json) = context_json {
-            let context = Context::new()
+        let context = match context_json {
+            Some(json) => Context::new()
                 .with_settings(json.as_str())
-                .map_err(WasmError::from)?;
-            Reader::from_context(context)
-                .with_fragment_async(format, init, fragment)
-                .await
-                .map_err(WasmError::from)?
-        } else {
-            Reader::from_fragment_async(format, init, fragment)
-                .await
-                .map_err(WasmError::from)?
+                .map_err(WasmError::from)?,
+            None => Context::new(),
         };
+        let reader = Reader::from_context(context)
+            .with_fragment_async(format, init, fragment)
+            .await
+            .map_err(WasmError::from)?;
 
         Ok(WasmReader::from_reader(reader).await)
     }

--- a/packages/c2pa-web/src/lib/builder.ts
+++ b/packages/c2pa-web/src/lib/builder.ts
@@ -146,6 +146,22 @@ export interface Builder {
   ) => Promise<void>;
 
   /**
+   * Experimental.
+   * Retains actions and ingredients together in one step.
+   *
+   * `rescueIngredient` is evaluated for every ingredient first; any action referencing an
+   * ingredient it would rescue is force-kept regardless of `keepAction`.
+   *
+   * @param keepAction The action is retained when the predicate returns true.
+   * @param rescueIngredient Can rescue an otherwise-orphaned ingredient (and the action
+   * referencing it) by returning true.
+   */
+  filterActionsAndIngredients: (
+    keepAction: (action: Action) => boolean,
+    rescueIngredient: (ingredient: Ingredient) => boolean
+  ) => Promise<void>;
+
+  /**
    * Add an ingredient to the builder from a definition only.
    *
    * @param ingredientDefinition {@link Ingredient} definition.
@@ -360,6 +376,35 @@ function createBuilder(
         return rescued;
       }, []);
       await tx.builder_filterIngredientsAt(id, indices);
+    },
+
+    async filterActionsAndIngredients(
+      keepAction: (action: Action) => boolean,
+      rescueIngredient: (ingredient: Ingredient) => boolean
+    ) {
+      const definition: ManifestDefinition = await tx.builder_getDefinition(id);
+      const actions = getActionsFromDefinition(definition);
+      const actionIndices = actions.reduce<number[]>((kept, action, i) => {
+        if (keepAction(action)) {
+          kept.push(i);
+        }
+        return kept;
+      }, []);
+      const ingredients: Ingredient[] = definition.ingredients ?? [];
+      const ingredientIndices = ingredients.reduce<number[]>(
+        (rescued, ingredient, i) => {
+          if (rescueIngredient(ingredient)) {
+            rescued.push(i);
+          }
+          return rescued;
+        },
+        []
+      );
+      await tx.builder_filterActionsAndIngredientsAt(
+        id,
+        actionIndices,
+        ingredientIndices
+      );
     },
 
     async addIngredient(ingredientDefinition: Ingredient) {

--- a/packages/c2pa-web/src/lib/worker.ts
+++ b/packages/c2pa-web/src/lib/worker.ts
@@ -117,6 +117,17 @@ rx(
       const builder = builderMap.get(builderId);
       builder.filterIngredientsAt(Uint32Array.from(indices));
     },
+    builder_filterActionsAndIngredientsAt(
+      builderId,
+      actionIndices,
+      ingredientIndices
+    ) {
+      const builder = builderMap.get(builderId);
+      builder.filterActionsAndIngredientsAt(
+        Uint32Array.from(actionIndices),
+        Uint32Array.from(ingredientIndices)
+      );
+    },
     builder_setRemoteUrl(builderId, url) {
       const builder = builderMap.get(builderId);
       builder.setRemoteUrl(url);

--- a/packages/c2pa-web/src/lib/worker/rpc.ts
+++ b/packages/c2pa-web/src/lib/worker/rpc.ts
@@ -58,6 +58,11 @@ const { createTx, rx } = channel<{
   builder_addRedaction: (builderId: number, uri: string, reason: C2paReason) => void;
   builder_filterActionsAt: (builderId: number, indices: number[]) => void;
   builder_filterIngredientsAt: (builderId: number, indices: number[]) => void;
+  builder_filterActionsAndIngredientsAt: (
+    builderId: number,
+    actionIndices: number[],
+    ingredientIndices: number[],
+  ) => void;
   builder_setRemoteUrl: (builderId: number, url: string) => void;
   builder_setNoEmbed: (builderId: number, noEmbed: boolean) => void;
   builder_setThumbnailFromBlob: (


### PR DESCRIPTION
Method from [feat: new builder method to combine filtering of actions and ingredients
(#2379)](https://github.com/contentauth/c2pa-rs/pull/2401#top)

* Remove deprecated methods and future proofing.