### PR TITLE
chore: Regenerate Cargo.lock for c2pa-rs 0.90.5

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "c2pa"
-version = "0.90.4"
+version = "0.90.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ada3379bed665e87de66966901fb7d476efd28985b038378cba9faa2c84199"
+checksum = "f4a148058892fe44fc4b373d74ad4817495ea8e2575664d5721e48abda6109ac"
 dependencies = [
  "asn1-rs",
  "async-generic",


### PR DESCRIPTION
We missed regenerating the `Cargo.lock` when we bumped the version in https://github.com/contentauth/c2pa-js/pull/175, which caused the [release](https://github.com/contentauth/c2pa-js/actions/runs/31058215723) to fail.