### PR TITLE
fix: c2pa-rs version bump to v0.90.12

### DIFF
--- a/.changeset/proud-candles-tap.md
+++ b/.changeset/proud-candles-tap.md
@@ -1,0 +1,7 @@
+---
+'@contentauth/c2pa-node': patch
+'@contentauth/c2pa-wasm': patch
+'@contentauth/c2pa-web': patch
+---
+
+c2pa-rs version bump to v0.90.12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "c2pa"
-version = "0.90.10"
+version = "0.90.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f16b41afe45c511ecc7c6adea96bd6ed67e3769c645a3fd122dc4cb0970826a"
+checksum = "0bcd2a168e8ce506789d4e5a66c286e5aa4944bc2181d75360b3ddf723ac4264"
 dependencies = [
  "asn1-rs",
  "async-generic",
@@ -3717,13 +3717,13 @@ dependencies = [
 
 [[package]]
 name = "sha1"
-version = "0.10.6"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+checksum = "aacc4cc499359472b4abe1bf11d0b12e688af9a805fa5e3016f9a386dc2d0214"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
+ "cpufeatures 0.3.0",
+ "digest 0.11.3",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-c2pa = { version = "=0.90.10", features = ["unstable_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
+c2pa = { version = "=0.90.12", features = ["unstable_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-v0.90.12
https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-v0.90.11