### PR TITLE
feat: Add isRetryableError and fetch options for FetchWithRetryOptions; do not retry on AbortError

### DIFF
--- a/.changeset/five-olives-repair.md
+++ b/.changeset/five-olives-repair.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-utilities': patch
+---
+
+Add isRetryableError and fetch as options on FetchWithRetryOptions.

--- a/packages/c2pa-utilities/src/fetchWithRetry.spec.ts
+++ b/packages/c2pa-utilities/src/fetchWithRetry.spec.ts
@@ -368,6 +368,33 @@ describe('fetchWithRetry', () => {
     const result = await fetchWithRetry('http://retryAfterOn503');
     expect(result).toBe('resolved after 503 retry-after');
   });
+
+  test('honors a custom isRetryableError, refusing to retry a network error retried by default', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('boom'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchWithRetry('http://customIsRetryableError', {
+        isRetryableError: () => false
+      })
+    ).rejects.toThrow('Network error fetching http://customIsRetryableError: boom');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  test('never retries an AbortError, even with a permissive isRetryableError', async () => {
+    const abortError = new DOMException('The operation was aborted', 'AbortError');
+    const fetchMock = vi.fn().mockRejectedValue(abortError);
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(
+      fetchWithRetry('http://abortedRequest', {
+        isRetryableError: () => true
+      })
+    ).rejects.toThrow(
+      'Network error fetching http://abortedRequest: The operation was aborted'
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('fetchWithRetryRaw', () => {

--- a/packages/c2pa-utilities/src/fetchWithRetry.spec.ts
+++ b/packages/c2pa-utilities/src/fetchWithRetry.spec.ts
@@ -454,4 +454,36 @@ describe('fetchWithRetryRaw', () => {
     const res = await fetchWithRetryRaw('http://rawRetry');
     await expect(res.text()).resolves.toBe('recovered');
   });
+
+  test('honors a custom fetch implementation, retrying through it instead of the global fetch', async () => {
+    let calls = 0;
+    const customFetch = vi.fn(async () => {
+      calls++;
+      if (calls === 1) {
+        return new Response(null, { status: 500 });
+      }
+      return new Response('via custom fetch');
+    });
+
+    const res = await fetchWithRetryRaw('http://ignoredByCustomFetch', undefined, {
+      fetch: customFetch
+    });
+
+    expect(customFetch).toHaveBeenCalledTimes(2);
+    await expect(res.text()).resolves.toBe('via custom fetch');
+  });
+
+  test('does not call the global fetch when a custom fetch implementation is provided', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const customFetch = vi.fn(async () => new Response('custom only'));
+
+    const res = await fetchWithRetryRaw('http://customFetchOnly', undefined, {
+      fetch: customFetch
+    });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    await expect(res.text()).resolves.toBe('custom only');
+  });
 });

--- a/packages/c2pa-utilities/src/fetchWithRetry.spec.ts
+++ b/packages/c2pa-utilities/src/fetchWithRetry.spec.ts
@@ -455,6 +455,51 @@ describe('fetchWithRetryRaw', () => {
     await expect(res.text()).resolves.toBe('recovered');
   });
 
+  test('preserves the given RequestInit across retries', async () => {
+    const receivedRequests: {
+      method: string;
+      header: string | null;
+      body: unknown;
+    }[] = [];
+
+    const recordRequest = async ({ request }: { request: Request }) => {
+      receivedRequests.push({
+        method: request.method,
+        header: request.headers.get('x-test-header'),
+        body: await request.json()
+      });
+    };
+
+    server.use(
+      http.post(
+        'http://rawRetryWithInit',
+        async (info) => {
+          await recordRequest(info);
+          return new HttpResponse(null, { status: 500 });
+        },
+        { once: true }
+      ),
+      http.post('http://rawRetryWithInit', async (info) => {
+        await recordRequest(info);
+        return HttpResponse.json({ ok: true });
+      })
+    );
+
+    const res = await fetchWithRetryRaw('http://rawRetryWithInit', {
+      method: 'POST',
+      headers: { 'x-test-header': 'value' },
+      body: JSON.stringify({ hello: 'world' })
+    });
+
+    expect(res.ok).toBe(true);
+    expect(receivedRequests).toHaveLength(2);
+    for (const received of receivedRequests) {
+      expect(received.method).toBe('POST');
+      expect(received.header).toBe('value');
+      expect(received.body).toEqual({ hello: 'world' });
+    }
+  });
+
   test('honors a custom fetch implementation, using it instead of the global fetch', async () => {
     const fetchMock = vi.fn();
     vi.stubGlobal('fetch', fetchMock);

--- a/packages/c2pa-utilities/src/fetchWithRetry.spec.ts
+++ b/packages/c2pa-utilities/src/fetchWithRetry.spec.ts
@@ -369,15 +369,15 @@ describe('fetchWithRetry', () => {
     expect(result).toBe('resolved after 503 retry-after');
   });
 
-  test('honors a custom isRetryableError, refusing to retry a network error retried by default', async () => {
-    const fetchMock = vi.fn().mockRejectedValue(new Error('boom'));
+  test('honors a custom isRetryableError', async () => {
+    const fetchMock = vi.fn().mockRejectedValue(new Error('error'));
     vi.stubGlobal('fetch', fetchMock);
 
     await expect(
       fetchWithRetry('http://customIsRetryableError', {
-        isRetryableError: () => false
+        isRetryableError: () => false // Nothing is retryable.
       })
-    ).rejects.toThrow('Network error fetching http://customIsRetryableError: boom');
+    ).rejects.toThrow('Network error fetching http://customIsRetryableError: error');
     expect(fetchMock).toHaveBeenCalledTimes(1);
   });
 
@@ -455,7 +455,10 @@ describe('fetchWithRetryRaw', () => {
     await expect(res.text()).resolves.toBe('recovered');
   });
 
-  test('honors a custom fetch implementation, retrying through it instead of the global fetch', async () => {
+  test('honors a custom fetch implementation, using it instead of the global fetch', async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+    
     let calls = 0;
     const customFetch = vi.fn(async () => {
       calls++;
@@ -469,21 +472,8 @@ describe('fetchWithRetryRaw', () => {
       fetch: customFetch
     });
 
+    expect(fetchMock).not.toHaveBeenCalled();
     expect(customFetch).toHaveBeenCalledTimes(2);
     await expect(res.text()).resolves.toBe('via custom fetch');
-  });
-
-  test('does not call the global fetch when a custom fetch implementation is provided', async () => {
-    const fetchMock = vi.fn();
-    vi.stubGlobal('fetch', fetchMock);
-
-    const customFetch = vi.fn(async () => new Response('custom only'));
-
-    const res = await fetchWithRetryRaw('http://customFetchOnly', undefined, {
-      fetch: customFetch
-    });
-
-    expect(fetchMock).not.toHaveBeenCalled();
-    await expect(res.text()).resolves.toBe('custom only');
   });
 });

--- a/packages/c2pa-utilities/src/fetchWithRetry.ts
+++ b/packages/c2pa-utilities/src/fetchWithRetry.ts
@@ -165,8 +165,10 @@ function assertValidUrl(input: string): void {
 /**
  * Fetches `input`, retrying on network errors and on responses whose status is deemed
  * retryable (see {@link FetchWithRetryOptions.isRetryableStatus}), with exponential backoff
- * (respecting a `Retry-After` header when present). Returns the raw, successful `Response` —
- * callers are responsible for reading and validating the body themselves (e.g. `.json()`,
+ * (respecting a `Retry-After` header when present). Gives up on receiving `AbortError` and
+ * does not retry.
+ * 
+ * Callers are responsible for reading and validating the body themselves (e.g. `.json()`,
  * `.text()`, streaming, or their own size cap), which makes this suitable for arbitrary
  * requests (custom methods, headers, bodies) rather than just simple GETs.
  *

--- a/packages/c2pa-utilities/src/fetchWithRetry.ts
+++ b/packages/c2pa-utilities/src/fetchWithRetry.ts
@@ -95,17 +95,15 @@ export interface FetchWithRetryOptions {
 
   /**
    * The underlying fetch implementation to use. Defaults to the global `fetch` when omitted.
-   * Useful for dependency injection — e.g. wrapping another HTTP client's own request pipeline
-   * (such as a `wretch` middleware's `next`, or a test double) with this shared retry mechanism
-   * instead of calling the global `fetch` directly.
+   * Useful for dependency injection, such as wrapping another HTTP client's own request pipeline
+   * (like `wretch` middleware's `next`, or a test mock).
    */
   fetch?: (input: string, init?: RequestInit) => Promise<Response>;
 }
 
 /**
- * @param error An error thrown by `fetch`.
- * @returns Whether `error` represents a deliberate abort (e.g. via `AbortSignal`), which should
- * never be retried regardless of {@link FetchWithRetryOptions.isRetryableError}.
+ * @param error The error to check, usually from a `fetch` call.
+ * @returns Whether `error` represents a deliberate `AbortError`.
  */
 function isAbortError(error: unknown): boolean {
   return error instanceof Error && error.name === 'AbortError';

--- a/packages/c2pa-utilities/src/fetchWithRetry.ts
+++ b/packages/c2pa-utilities/src/fetchWithRetry.ts
@@ -85,6 +85,22 @@ export interface FetchWithRetryOptions {
    * always retried regardless of this predicate.
    */
   isRetryableStatus?: (status: number) => boolean;
+
+  /**
+   * Predicate deciding whether a given network error (thrown by the underlying `fetch` call)
+   * should be retried. Defaults to always retrying when omitted. Regardless of this predicate,
+   * an `AbortError` is never retried, since retrying a deliberate cancellation is never correct.
+   */
+  isRetryableError?: (error: unknown) => boolean;
+}
+
+/**
+ * @param error An error thrown by `fetch`.
+ * @returns Whether `error` represents a deliberate abort (e.g. via `AbortSignal`), which should
+ * never be retried regardless of {@link FetchWithRetryOptions.isRetryableError}.
+ */
+function isAbortError(error: unknown): boolean {
+  return error instanceof Error && error.name === 'AbortError';
 }
 
 /**
@@ -167,6 +183,7 @@ export async function fetchWithRetryRaw(
   const maxRetryDelayMs = options?.maxRetryDelayMs ?? DEFAULT_MAX_RETRY_DELAY_MS;
   const maxRetryAfterMs = options?.maxRetryAfterMs ?? DEFAULT_MAX_RETRY_AFTER_MS;
   const isRetryableStatus = options?.isRetryableStatus ?? defaultIsRetryableStatus;
+  const isRetryableError = options?.isRetryableError ?? (() => true);
 
   const backoff = (attempt: number) =>
     calculateBackoffMs(attempt, initialRetryDelayMs, maxRetryDelayMs);
@@ -176,7 +193,7 @@ export async function fetchWithRetryRaw(
     try {
       res = await fetch(input, init);
     } catch (e) {
-      if (attempt < maxRetries) {
+      if (!isAbortError(e) && attempt < maxRetries && isRetryableError(e)) {
         await new Promise((resolve) => setTimeout(resolve, backoff(attempt)));
         continue;
       }

--- a/packages/c2pa-utilities/src/fetchWithRetry.ts
+++ b/packages/c2pa-utilities/src/fetchWithRetry.ts
@@ -92,6 +92,14 @@ export interface FetchWithRetryOptions {
    * an `AbortError` is never retried, since retrying a deliberate cancellation is never correct.
    */
   isRetryableError?: (error: unknown) => boolean;
+
+  /**
+   * The underlying fetch implementation to use. Defaults to the global `fetch` when omitted.
+   * Useful for dependency injection — e.g. wrapping another HTTP client's own request pipeline
+   * (such as a `wretch` middleware's `next`, or a test double) with this shared retry mechanism
+   * instead of calling the global `fetch` directly.
+   */
+  fetch?: (input: string, init?: RequestInit) => Promise<Response>;
 }
 
 /**
@@ -184,6 +192,7 @@ export async function fetchWithRetryRaw(
   const maxRetryAfterMs = options?.maxRetryAfterMs ?? DEFAULT_MAX_RETRY_AFTER_MS;
   const isRetryableStatus = options?.isRetryableStatus ?? defaultIsRetryableStatus;
   const isRetryableError = options?.isRetryableError ?? (() => true);
+  const doFetch = options?.fetch ?? fetch;
 
   const backoff = (attempt: number) =>
     calculateBackoffMs(attempt, initialRetryDelayMs, maxRetryDelayMs);
@@ -191,7 +200,7 @@ export async function fetchWithRetryRaw(
   for (let attempt = 0; ; attempt++) {
     let res: Response;
     try {
-      res = await fetch(input, init);
+      res = await doFetch(input, init);
     } catch (e) {
       if (!isAbortError(e) && attempt < maxRetries && isRetryableError(e)) {
         await new Promise((resolve) => setTimeout(resolve, backoff(attempt)));

--- a/packages/c2pa-utilities/src/fetchWithRetry.ts
+++ b/packages/c2pa-utilities/src/fetchWithRetry.ts
@@ -80,16 +80,17 @@ export interface FetchWithRetryOptions {
   maxRetryAfterMs?: number;
 
   /**
-   * Predicate deciding whether a given HTTP response status should be retried. Defaults to
-   * {@link defaultIsRetryableStatus} (`429` or any `5xx`) when omitted. Network errors are
-   * always retried regardless of this predicate.
+   * Predicate contributing to decision on whether a given HTTP response status should be retried. 
+   * Defaults to {@link defaultIsRetryableStatus} (`429` or any `5xx`) when omitted.
    */
   isRetryableStatus?: (status: number) => boolean;
 
   /**
-   * Predicate deciding whether a given network error (thrown by the underlying `fetch` call)
-   * should be retried. Defaults to always retrying when omitted. Regardless of this predicate,
-   * an `AbortError` is never retried, since retrying a deliberate cancellation is never correct.
+   * Predicate contributing to decision on whether a given network error (thrown by the underlying 
+   * `fetch` call) should be retried.
+   * 
+   * Defaults to always retrying when omitted. Regardless of this predicate, an `AbortError` is
+   * never retried, since retrying a deliberate cancellation is never correct.
    */
   isRetryableError?: (error: unknown) => boolean;
 
@@ -202,7 +203,7 @@ export async function fetchWithRetryRaw(
     try {
       res = await fetchFn(input, init);
     } catch (e) {
-      if (!isAbortError(e) && attempt < maxRetries && isRetryableError(e)) {
+      if (!isAbortError(e) && isRetryableError(e) && attempt < maxRetries) {
         await new Promise((resolve) => setTimeout(resolve, backoff(attempt)));
         continue;
       }

--- a/packages/c2pa-utilities/src/fetchWithRetry.ts
+++ b/packages/c2pa-utilities/src/fetchWithRetry.ts
@@ -190,7 +190,7 @@ export async function fetchWithRetryRaw(
   const maxRetryAfterMs = options?.maxRetryAfterMs ?? DEFAULT_MAX_RETRY_AFTER_MS;
   const isRetryableStatus = options?.isRetryableStatus ?? defaultIsRetryableStatus;
   const isRetryableError = options?.isRetryableError ?? (() => true);
-  const doFetch = options?.fetch ?? fetch;
+  const fetchFn = options?.fetch ?? fetch;
 
   const backoff = (attempt: number) =>
     calculateBackoffMs(attempt, initialRetryDelayMs, maxRetryDelayMs);
@@ -198,7 +198,7 @@ export async function fetchWithRetryRaw(
   for (let attempt = 0; ; attempt++) {
     let res: Response;
     try {
-      res = await doFetch(input, init);
+      res = await fetchFn(input, init);
     } catch (e) {
       if (!isAbortError(e) && attempt < maxRetries && isRetryableError(e)) {
         await new Promise((resolve) => setTimeout(resolve, backoff(attempt)));


### PR DESCRIPTION
Adds new options to `FetchWithRetryOptions`:
- `isRetryableError`: optional predicate accepting an error code and returning whether the code is retryable
- `fetch`: optional function matching the shape of `fetch` to allow overrides of fetch behavior, and allow injection of fetch functionality such as those provided through `wretch`

Also, do not allow retry on `AbortError`s.