### PR TITLE
fix: Bump c2pa-rs version to v0.90.15

### DIFF
--- a/.changeset/ripe-donkeys-do.md
+++ b/.changeset/ripe-donkeys-do.md
@@ -1,0 +1,7 @@
+---
+'@contentauth/c2pa-node': patch
+'@contentauth/c2pa-wasm': patch
+'@contentauth/c2pa-web': patch
+---
+
+Bump c2pa-rs to v0.90.15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "c2pa"
-version = "0.90.14"
+version = "0.90.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a076691251ac817a33f1d089f16e994f900204f750caad00c14b4881cc499ca5"
+checksum = "0de890fccb64664b95b0a1beea2bffbd95f898774ea04658ef28f3793cf58bc9"
 dependencies = [
  "asn1-rs",
  "async-generic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-c2pa = { version = "=0.90.14", features = ["unstable_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
+c2pa = { version = "=0.90.15", features = ["unstable_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-v0.90.15