### PR TITLE
fix: apply temporary changeset patch to fix c2pa-node and c2pa-web workspace dependencies

### DIFF
--- a/.changeset/fix-node-workspace-dependency.md
+++ b/.changeset/fix-node-workspace-dependency.md
@@ -1,0 +1,5 @@
+---
+"@contentauth/c2pa-node": patch
+---
+
+Republish to fix `@contentauth/c2pa-utilities` dependency, which resolved to `0.2.0` — the broken version published with an unresolved `workspace:*` dependency of its own (see the `c2pa-utilities` patch in this same release). This release has no source changes; it exists to pick up the corrected `c2pa-utilities` version once published.

--- a/.changeset/fix-web-workspace-dependency.md
+++ b/.changeset/fix-web-workspace-dependency.md
@@ -1,0 +1,5 @@
+---
+"@contentauth/c2pa-web": patch
+---
+
+Republish to fix `@contentauth/c2pa-types`, `@contentauth/c2pa-utilities`, and `@contentauth/c2pa-wasm` dependencies, which were published as the literal string `workspace:*` instead of resolved versions. This happened because this package's publish ran concurrently with `c2pa-node`'s in the same release, hitting a race in pnpm's workspace-protocol rewrite during `pnpm publish` (now patched to publish serially). No source changes are included; this release exists solely to get a correctly published package out.

--- a/patches/@changesets__cli@2.31.0.patch
+++ b/patches/@changesets__cli@2.31.0.patch
@@ -1,0 +1,34 @@
+diff --git a/dist/changesets-cli.cjs.js b/dist/changesets-cli.cjs.js
+index 9f0bd6c5f96011be225269a71365a878cb822bb7..69d61c92d76eda7cc6fd30bf487379c45e0a1e2e 100644
+--- a/dist/changesets-cli.cjs.js
++++ b/dist/changesets-cli.cjs.js
+@@ -702,7 +702,11 @@ const getLastJsonObjectFromString = str => {
+ };
+ 
+ const NPM_REQUEST_CONCURRENCY_LIMIT = 40;
+-const NPM_PUBLISH_CONCURRENCY_LIMIT = 10;
++// Patched: force serial publishing. pnpm's `workspace:*` rewrite-then-restore
++// during `pnpm publish` races when multiple publishes run concurrently in the
++// same workspace, which can leave a package published with an unrewritten
++// literal "workspace:*" dependency instead of a resolved version.
++const NPM_PUBLISH_CONCURRENCY_LIMIT = 1;
+ const NPM_REGISTRY = "https://registry.npmjs.org";
+ const YARN_REGISTRY = "https://registry.yarnpkg.com";
+ const npmRequestQueue = createPromiseQueue(NPM_REQUEST_CONCURRENCY_LIMIT);
+diff --git a/dist/changesets-cli.esm.js b/dist/changesets-cli.esm.js
+index d9582bf53eaf55402a6bf96a39589af7854b8f23..455f47db61adc14e00e19db5df360a297fbd2cfd 100644
+--- a/dist/changesets-cli.esm.js
++++ b/dist/changesets-cli.esm.js
+@@ -665,7 +665,11 @@ const getLastJsonObjectFromString = str => {
+ };
+ 
+ const NPM_REQUEST_CONCURRENCY_LIMIT = 40;
+-const NPM_PUBLISH_CONCURRENCY_LIMIT = 10;
++// Patched: force serial publishing. pnpm's `workspace:*` rewrite-then-restore
++// during `pnpm publish` races when multiple publishes run concurrently in the
++// same workspace, which can leave a package published with an unrewritten
++// literal "workspace:*" dependency instead of a resolved version.
++const NPM_PUBLISH_CONCURRENCY_LIMIT = 1;
+ const NPM_REGISTRY = "https://registry.npmjs.org";
+ const YARN_REGISTRY = "https://registry.yarnpkg.com";
+ const npmRequestQueue = createPromiseQueue(NPM_REQUEST_CONCURRENCY_LIMIT);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  '@changesets/cli@2.31.0':
+    hash: 3a8bdb9beaa04fc87b82cb2d08e95cc959c23a3a5a384098b71a2d25751dc6be
+    path: patches/@changesets__cli@2.31.0.patch
+
 importers:
 
   .:
@@ -143,7 +148,7 @@ importers:
     devDependencies:
       '@changesets/cli':
         specifier: ^2.31.0
-        version: 2.31.0(@types/node@22.19.20)
+        version: 2.31.0(patch_hash=3a8bdb9beaa04fc87b82cb2d08e95cc959c23a3a5a384098b71a2d25751dc6be)(@types/node@22.19.20)
       '@eslint/js':
         specifier: ^9.39.4
         version: 9.39.4
@@ -8516,7 +8521,7 @@ snapshots:
     transitivePeerDependencies:
       - '@types/node'
 
-  '@changesets/cli@2.31.0(@types/node@22.19.20)':
+  '@changesets/cli@2.31.0(patch_hash=3a8bdb9beaa04fc87b82cb2d08e95cc959c23a3a5a384098b71a2d25751dc6be)(@types/node@22.19.20)':
     dependencies:
       '@changesets/apply-release-plan': 7.1.1
       '@changesets/assemble-release-plan': 6.0.10

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,3 +9,6 @@ onlyBuiltDependencies:
   - nx
   - sharp
   - unrs-resolver
+
+patchedDependencies:
+  '@changesets/cli@2.31.0': patches/@changesets__cli@2.31.0.patch


### PR DESCRIPTION
Apply temporary changeset patch to fix c2pa-node and c2pa-web workspace dependencies. 

We need to merge this into `main` to ensure serial publishing of the packages when https://github.com/contentauth/c2pa-js/pull/193 is merged into `main` and triggers the release pipeline on CI. That will cause `c2pa-utilities` to publish first as v0.2.1, followed by `c2pa-node` v0.9.1 and `c2pa-web` v0.14.1.

A follow-up PR will delete the patch.