### PR TITLE
feat(c2pa-utilities): Introduce Context class

### DIFF
--- a/.changeset/blue-jobs-allow.md
+++ b/.changeset/blue-jobs-allow.md
@@ -1,5 +1,5 @@
 ---
-'@contentauth/c2pa-utilities': minor
+'@contentauth/c2pa-utilities': major
 '@contentauth/c2pa-web': patch
 ---
 

--- a/.changeset/blue-jobs-allow.md
+++ b/.changeset/blue-jobs-allow.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-utilities': minor
+---
+
+Introduce Context, deprecate thread-local Settings.

--- a/.changeset/blue-jobs-allow.md
+++ b/.changeset/blue-jobs-allow.md
@@ -1,6 +1,5 @@
 ---
 '@contentauth/c2pa-utilities': minor
-'@contentauth/c2pa-wasm': patch
 '@contentauth/c2pa-web': patch
 ---
 

--- a/.changeset/blue-jobs-allow.md
+++ b/.changeset/blue-jobs-allow.md
@@ -1,5 +1,7 @@
 ---
 '@contentauth/c2pa-utilities': minor
+'@contentauth/c2pa-wasm': patch
+'@contentauth/c2pa-web': patch
 ---
 
 Introduce Context, deprecate thread-local Settings.

--- a/.changeset/blue-jobs-allow.md
+++ b/.changeset/blue-jobs-allow.md
@@ -3,4 +3,4 @@
 '@contentauth/c2pa-web': patch
 ---
 
-Introduce Context, deprecate thread-local Settings.
+Introduce Context class as a wrapper around Settings for configuring Readers and Builders. Add temporary shim in c2pa-web.

--- a/.changeset/blue-jobs-allow.md
+++ b/.changeset/blue-jobs-allow.md
@@ -1,5 +1,5 @@
 ---
-'@contentauth/c2pa-utilities': major
+'@contentauth/c2pa-utilities': minor
 '@contentauth/c2pa-web': patch
 ---
 

--- a/packages/c2pa-utilities/README.md
+++ b/packages/c2pa-utilities/README.md
@@ -14,9 +14,53 @@ Complete API documentation is generated from TypeScript source using [TypeDoc](h
 
 ## Utilities
 
-### Settings
+### `Context` and `Settings`
 
-Helpers for building, merging, and serializing the `Settings` object consumed by `c2pa-web`'s and `c2pa-node`'s `Reader`/`Builder` constructors.
+`Settings` is a plain, JSON-serializable object describing SDK behavior — trust anchors, verification options, and builder options. `Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure the SDK. Clients should create and attach a `Context` once at SDK-initialization time, which then configures every `Reader`/`Builder` created afterwards. It is not passed to individual `Reader`/`Builder` instances or their per-call methods. See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-the-sdk-with-context) for an example.
+
+#### Creating a `Context`
+
+```typescript
+import { Context } from '@contentauth/c2pa-utilities';
+
+const context = new Context({
+  verify: {
+    verifyTrust: true
+  },
+  trust: {
+    trustAnchors: 'https://example.com/trust-anchors.pem'
+  }
+});
+```
+
+#### Combining `Settings`
+
+`Context` doesn't merge settings for you — each `Context` just holds whatever single `Settings` object was passed to its constructor. To combine more than one `Settings` source, merge them first with `mergeSettings()`, then construct a `Context` from the single, merged result:
+
+```typescript
+import { Context, mergeSettings } from '@contentauth/c2pa-utilities';
+
+const base = { verify: { verifyTrust: true } };
+const override = { verify: { verifyAfterSign: true } };
+
+const context = new Context(mergeSettings(base, override));
+// context.settings is { verify: { verifyTrust: true, verifyAfterSign: true } }
+```
+
+#### Resolving a `Context` to JSON
+
+Bindings pass settings across their JS-to-wasm/native boundary as a JSON string. `toJson()` resolves any trust-anchor URLs embedded in the settings (fetching and validating them) and serializes the result:
+
+```typescript
+const contextJson = await context.toJson();
+// '{"verify":{"verify_trust":true},"trust":{"trust_anchors":"-----BEGIN CERTIFICATE-----..."}}'
+```
+
+This step is asynchronous, and can throw if a trust-anchor URL fails to resolve. Bindings call it once, right after building the base `Context`, rather than on every `Reader`/`Builder` call. Internally, `toJson()` is a thin wrapper over `resolveSettings`, below.
+
+#### Building `Settings` directly
+
+`Context` is built on a handful of lower-level `Settings` helpers, which remain available directly for cases that don't need a `Context` at all:
 
 ```typescript
 import {
@@ -37,18 +81,19 @@ const verifySettings = createVerifySettings({
 
 const settings = mergeSettings(trustSettings, verifySettings);
 
-// Merges any override on top of base, fetches trust-anchor URLs, and serializes
-// to the snake_case JSON string the native SDK expects.
-const settingsJson = await resolveSettings(settings, undefined);
+// Resolves trust-anchor URLs and serializes to the snake_case JSON string the
+// native SDK expects. `Context.toJson()` calls this internally.
+const settingsJson = await resolveSettings(settings);
 ```
 
-`resolveSettings` is the top-level entry point most callers want: it deep-merges `overrideSettings` on top of `baseSettings`, resolves any `trust`/`cawgTrust` fields that are URLs (fetching and inlining the PEM content, retrying transient failures), and returns the result as a snake_case JSON string. Pass `undefined` for either argument to skip that step; passing `undefined` for both returns `undefined`.
+`resolveSettings` is the entry point most direct callers want: it resolves any `trust`/`cawgTrust` fields that are URLs (fetching and inlining the PEM content, retrying transient failures), and returns the result as a snake_case JSON string. `settings` is merged on top of this package's defaults, so `resolveSettings` always returns a value, even when called with `undefined`. To combine more than one `Settings` object first, merge them with `mergeSettings()` before calling `resolveSettings`, as above.
 
 Other exports:
 
 - `createTrustSettings` / `createCawgTrustSettings` / `createVerifySettings` — construct a `Settings` fragment for one section.
 - `mergeSettings` — deep-merge any number of `Settings` fragments, with later arguments overriding earlier ones. Nested fields are merged rather than overwritten.
 - `settingsToJson` — serialize a `Settings` object to its snake_case JSON form without resolving trust-anchor URLs.
+- `snakeCaseify` — the lower-level camelCase-to-snake_case object converter `settingsToJson`/`resolveSettings` use internally.
 - `loadSettingsFromUrl` — fetch a settings JSON document from a URL, with retry.
 - `resolveTrustSettings` — resolve just a `TrustSettings` object's URL fields in place; used internally by `resolveSettings`.
 

--- a/packages/c2pa-utilities/README.md
+++ b/packages/c2pa-utilities/README.md
@@ -16,7 +16,11 @@ Complete API documentation is generated from TypeScript source using [TypeDoc](h
 
 ### `Context` and `Settings`
 
-`Settings` is a plain, JSON-serializable object configuring SDK behavior around trust anchors, verification options, and `Reader`/`Builder` options. `Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure a `Reader`/`Builder`. `Context` objects are passed directly to the call that creates a `Reader`/`Builder` instance, so one running SDK instance can freely create many different `Reader`/`Builder`s, each with its own `Context`. See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-behavior-with-context) for an example.
+`Settings` is a plain, JSON-serializable object configuring SDK behavior around trust anchors, verification options, and `Reader`/`Builder` options.
+
+`Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure a `Reader`/`Builder`. `Context` objects are passed directly to the call that creates a `Reader`/`Builder` instance, so one running SDK instance can freely create many different `Reader`/`Builder`s, each with its own `Context`. `Context` changes do not propagate, since the `Context` is snapshotted when used to construct a `Reader`/`Builder`. Therefore, it can be safely used to construct multiple instances.
+
+See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-behavior-with-context) for an example.
 
 #### Creating a `Context`
 

--- a/packages/c2pa-utilities/README.md
+++ b/packages/c2pa-utilities/README.md
@@ -16,7 +16,7 @@ Complete API documentation is generated from TypeScript source using [TypeDoc](h
 
 ### `Context` and `Settings`
 
-`Settings` is a plain, JSON-serializable object configuring SDK behavior around trust anchors, verification options, and `Reader`/`Builder` options. `Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure a `Reader`/`Builder`. `Context` objects are passed directly to the call that creates a `Reader`/`Builder`  instance, so one running SDK instance can freely create many different `Reader`/`Builder`s, each with its own `Context`. See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-behavior-with-context) for an example.
+`Settings` is a plain, JSON-serializable object configuring SDK behavior around trust anchors, verification options, and `Reader`/`Builder` options. `Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure a `Reader`/`Builder`. `Context` objects are passed directly to the call that creates a `Reader`/`Builder` instance, so one running SDK instance can freely create many different `Reader`/`Builder`s, each with its own `Context`. See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-behavior-with-context) for an example.
 
 #### Creating a `Context`
 

--- a/packages/c2pa-utilities/README.md
+++ b/packages/c2pa-utilities/README.md
@@ -16,7 +16,7 @@ Complete API documentation is generated from TypeScript source using [TypeDoc](h
 
 ### `Context` and `Settings`
 
-`Settings` is a plain, JSON-serializable object describing SDK behavior — trust anchors, verification options, and builder options. `Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure a `Reader`/`Builder`. A binding passes a `Context` directly to the call that creates a `Reader`/`Builder` (alongside whatever runtime handle that binding needs), so one running SDK instance can freely create many `Reader`/`Builder`s, each with its own `Context`. See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-behavior-with-context) for an example.
+`Settings` is a plain, JSON-serializable object configuring SDK behavior around trust anchors, verification options, and `Reader`/`Builder` options. `Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure a `Reader`/`Builder`. `Context` objects are passed directly to the call that creates a `Reader`/`Builder`  instance, so one running SDK instance can freely create many different `Reader`/`Builder`s, each with its own `Context`. See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-behavior-with-context) for an example.
 
 #### Creating a `Context`
 
@@ -49,7 +49,7 @@ const context = new Context(mergeSettings(base, override));
 
 #### Resolving a `Context` to JSON
 
-Bindings pass settings across their wasm/native boundary as a JSON string. `toJson()` resolves any trust-anchor URLs embedded in the settings (fetching and validating them) and serializes the result:
+Settings are passed across the WASM (`c2pa-web`)/native(`c2pa-node`) boundary as a JSON string. `toJson()` resolves any trust-anchor URLs embedded in the settings (fetching and validating them) and serializes the result:
 
 ```typescript
 const contextJson = await context.toJson();
@@ -81,8 +81,7 @@ const verifySettings = createVerifySettings({
 
 const settings = mergeSettings(trustSettings, verifySettings);
 
-// Resolves trust-anchor URLs and serializes to the snake_case JSON string the
-// native SDK expects. `Context.toJson()` calls this internally.
+// Resolves trust-anchor URLs and serializes to the snake_case JSON string the native SDK expects.
 const settingsJson = await resolveSettings(settings);
 ```
 

--- a/packages/c2pa-utilities/README.md
+++ b/packages/c2pa-utilities/README.md
@@ -16,7 +16,7 @@ Complete API documentation is generated from TypeScript source using [TypeDoc](h
 
 ### `Context` and `Settings`
 
-`Settings` is a plain, JSON-serializable object describing SDK behavior — trust anchors, verification options, and builder options. `Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure the SDK. Clients should create and attach a `Context` once at SDK-initialization time, which then configures every `Reader`/`Builder` created afterwards. It is not passed to individual `Reader`/`Builder` instances or their per-call methods. See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-the-sdk-with-context) for an example.
+`Settings` is a plain, JSON-serializable object describing SDK behavior — trust anchors, verification options, and builder options. `Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure the SDK. Clients should create and attach a `Context` once at SDK initialization or `Reader`/`Builder` construction time, which then configures the behavior of those readers and builders going forward. See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-the-sdk-with-context) for an example.
 
 #### Creating a `Context`
 

--- a/packages/c2pa-utilities/README.md
+++ b/packages/c2pa-utilities/README.md
@@ -16,7 +16,7 @@ Complete API documentation is generated from TypeScript source using [TypeDoc](h
 
 ### `Context` and `Settings`
 
-`Settings` is a plain, JSON-serializable object describing SDK behavior — trust anchors, verification options, and builder options. `Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure the SDK. Clients should create and attach a `Context` once at SDK initialization or `Reader`/`Builder` construction time, which then configures the behavior of those readers and builders going forward. See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-the-sdk-with-context) for an example.
+`Settings` is a plain, JSON-serializable object describing SDK behavior — trust anchors, verification options, and builder options. `Context` is a small, immutable wrapper around `Settings`, and is the recommended way to configure a `Reader`/`Builder`. A binding passes a `Context` directly to the call that creates a `Reader`/`Builder` (alongside whatever runtime handle that binding needs), so one running SDK instance can freely create many `Reader`/`Builder`s, each with its own `Context`. See [`c2pa-web`'s README](../c2pa-web/README.md#configuring-behavior-with-context) for an example.
 
 #### Creating a `Context`
 

--- a/packages/c2pa-utilities/README.md
+++ b/packages/c2pa-utilities/README.md
@@ -35,7 +35,7 @@ const context = new Context({
 
 #### Combining `Settings`
 
-`Context` doesn't merge settings for you — each `Context` just holds whatever single `Settings` object was passed to its constructor. To combine more than one `Settings` source, merge them first with `mergeSettings()`, then construct a `Context` from the single, merged result:
+Each `Context` holds whatever single `Settings` object was passed to its constructor and does not handle any merging of settings. To combine more than one `Settings` source, merge them first with `mergeSettings()`, then construct a `Context` from the single, merged result:
 
 ```typescript
 import { Context, mergeSettings } from '@contentauth/c2pa-utilities';
@@ -49,7 +49,7 @@ const context = new Context(mergeSettings(base, override));
 
 #### Resolving a `Context` to JSON
 
-Bindings pass settings across their JS-to-wasm/native boundary as a JSON string. `toJson()` resolves any trust-anchor URLs embedded in the settings (fetching and validating them) and serializes the result:
+Bindings pass settings across their wasm/native boundary as a JSON string. `toJson()` resolves any trust-anchor URLs embedded in the settings (fetching and validating them) and serializes the result:
 
 ```typescript
 const contextJson = await context.toJson();
@@ -86,7 +86,7 @@ const settings = mergeSettings(trustSettings, verifySettings);
 const settingsJson = await resolveSettings(settings);
 ```
 
-`resolveSettings` is the entry point most direct callers want: it resolves any `trust`/`cawgTrust` fields that are URLs (fetching and inlining the PEM content, retrying transient failures), and returns the result as a snake_case JSON string. `settings` is merged on top of this package's defaults, so `resolveSettings` always returns a value, even when called with `undefined`. To combine more than one `Settings` object first, merge them with `mergeSettings()` before calling `resolveSettings`, as above.
+`resolveSettings` is the entry point most direct callers want. It resolves any `trust`/`cawgTrust` URL fields (fetching and inlining the PEM content, retrying transient failures), and returns the result as a snake_case JSON string. `settings` is merged on top of this package's defaults, so `resolveSettings` always returns a value, even when called with `undefined`. To combine more than one `Settings` object first, merge them with `mergeSettings()` before calling `resolveSettings`, as above.
 
 Other exports:
 

--- a/packages/c2pa-utilities/src/context.spec.ts
+++ b/packages/c2pa-utilities/src/context.spec.ts
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { Context } from './context.js';
+import { DEFAULT_SETTINGS, settingsToJson } from './settings.js';
+
+describe('Context', () => {
+  test('new Context() with no settings resolves to defaults', async () => {
+    const result = await new Context().toJson();
+    expect(result).toEqual(settingsToJson(DEFAULT_SETTINGS));
+  });
+
+  test('settings getter returns what was attached', () => {
+    expect(new Context().settings).toBeUndefined();
+
+    const settings = { verify: { verifyTrust: false } };
+    expect(new Context(settings).settings).toEqual(settings);
+  });
+
+  test('constructing with settings resolves the given settings', async () => {
+    const result = await new Context({
+      verify: { verifyTrust: false }
+    }).toJson();
+
+    // Result should contain the defaults that the given settings are merged with.
+    expect(result).toEqual(
+      JSON.stringify({
+        builder: { generate_c2pa_archive: true },
+        verify: { verify_trust: false }
+      })
+    );
+  });
+});

--- a/packages/c2pa-utilities/src/context.spec.ts
+++ b/packages/c2pa-utilities/src/context.spec.ts
@@ -38,7 +38,7 @@ describe('Context', () => {
     );
   });
 
-  test('toJson() memoizes: repeated calls return the exact same Promise', async () => {
+  test('successful toJson() calls should be memoized', async () => {
     const context = new Context({ verify: { verifyTrust: false } });
 
     const first = context.toJson();
@@ -51,5 +51,38 @@ describe('Context', () => {
         verify: { verify_trust: false }
       })
     );
+  });
+
+  test('failed toJson() calls should not be memoized', async () => {
+    const context = new Context({
+      trust: { trustAnchors: 'https://example.com/anchors.pem' }
+    });
+
+    const failingFetch = async (): Promise<Response> => {
+      throw new Error('network down');
+    };
+
+    const first = context.toJson({ fetch: failingFetch, maxRetries: 0 });
+    await expect(first).rejects.toThrow();
+
+    const succeedingFetch = async (): Promise<Response> =>
+      new Response(
+        '-----BEGIN CERTIFICATE-----\nabcd\n-----END CERTIFICATE-----'
+      );
+
+    const second = context.toJson({ fetch: succeedingFetch });
+
+    // A fresh attempt (a new Promise, not the previously-rejected one), which succeeds.
+    expect(second).not.toBe(first);
+    const result = await second;
+    expect(JSON.parse(result)).toMatchObject({
+      trust: {
+        trust_anchors:
+          '-----BEGIN CERTIFICATE-----\nabcd\n-----END CERTIFICATE-----'
+      }
+    });
+
+    // The successful resolution is memoized as usual from here on.
+    expect(context.toJson()).toBe(second);
   });
 });

--- a/packages/c2pa-utilities/src/context.spec.ts
+++ b/packages/c2pa-utilities/src/context.spec.ts
@@ -37,4 +37,19 @@ describe('Context', () => {
       })
     );
   });
+
+  test('toJson() memoizes: repeated calls return the exact same Promise', async () => {
+    const context = new Context({ verify: { verifyTrust: false } });
+
+    const first = context.toJson();
+    const second = context.toJson();
+
+    expect(second).toBe(first);
+    await expect(first).resolves.toEqual(
+      JSON.stringify({
+        builder: { generate_c2pa_archive: true },
+        verify: { verify_trust: false }
+      })
+    );
+  });
 });

--- a/packages/c2pa-utilities/src/context.ts
+++ b/packages/c2pa-utilities/src/context.ts
@@ -11,10 +11,10 @@ import type { FetchWithRetryOptions } from './fetchWithRetry.js';
 import { resolveSettings, type Settings } from './settings.js';
 
 /**
- * A `Context` configures the behavior of a single `Reader`/`Builder`. Bindings attach it at
- * creation time (e.g. `Reader.fromBlob(c2pa, format, blob, context)`), independent of whatever
- * runtime/worker handle that creation call also needs — so one running SDK instance can freely
- * create many `Reader`/`Builder`s, each with its own `Context`.
+ * A `Context` configures the behavior of a single `Reader`/`Builder`. 
+ * 
+ * It is provided at creation time (e.g. `Reader.fromBlob(c2pa, format, blob, context)`),
+ * configuring that instance's behavior independently of other instances.
  */
 export class Context {
   private readonly _settings?: Settings;
@@ -25,10 +25,11 @@ export class Context {
   }
 
   /**
-   * The settings currently attached to this `Context`, if any. To derive a new `Context` with
-   * different settings, construct one with `new Context(settings)` — to combine this `Context`'s
-   * settings with more, merge them with {@link mergeSettings} first and pass the single result to
-   * the constructor.
+   * The settings currently attached to this `Context`, if any.
+   * 
+   * To derive a new `Context` with different settings, construct one with `new Context(settings)`.
+   * To combine this `Context`'s settings with more settings, merge them with {@link mergeSettings}
+   * first and pass the single, merged result to the constructor.
    */
   get settings(): Settings | undefined {
     return this._settings;
@@ -36,13 +37,10 @@ export class Context {
 
   /**
    * Resolves this `Context`'s settings (fetching any embedded trust-anchor URLs) and serializes
-   * the result for consumption by the native/wasm boundary.
-   *
-   * Memoized: since a `Context`'s settings never change after construction, the result (and any
-   * trust-anchor fetch it took to produce it) is only ever computed once, on the first call, and
-   * reused for every call after — including calls with different `options` than the first one
-   * used. Callers that need the same `Context` resolved under two different `options` should
-   * construct two separate `Context`s instead.
+   * the result for consumption by the WASM/native boundary. The result is memoized, so resolution
+   * of this Context's settings should only ever happen once. If different fetch-with-retry options
+   * need to be provided, callers should create a separate `Context` and then call `toJson()`
+   * with the desired options.
    *
    * @param options Optional configurations for fetch-with-retry, used when resolving trust-anchor
    * URLs. Only consulted on the first call.

--- a/packages/c2pa-utilities/src/context.ts
+++ b/packages/c2pa-utilities/src/context.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright 2026 Adobe
+ * All Rights Reserved.
+ *
+ * NOTICE: Adobe permits you to use, modify, and distribute this file in
+ * accordance with the terms of the Adobe license agreement accompanying
+ * it.
+ */
+
+import type { FetchWithRetryOptions } from './fetchWithRetry.js';
+import { resolveSettings, type Settings } from './settings.js';
+
+/**
+ * A `Context` configures the behavior of every `Reader`/`Builder` created with
+ * any given instance of the SDK (see {@link C2paSdk}).
+ * 
+ * It is attached once at SDK/factory-initialization time.
+ */
+export class Context {
+  private readonly _settings?: Settings;
+
+  constructor(settings?: Settings) {
+    this._settings = settings;
+  }
+
+  /**
+   * The settings currently attached to this `Context`, if any. To derive a new `Context` with
+   * different settings, construct one with `new Context(settings)` — to combine this `Context`'s
+   * settings with more, merge them with {@link mergeSettings} first and pass the single result to
+   * the constructor.
+   */
+  get settings(): Settings | undefined {
+    return this._settings;
+  }
+
+  /**
+   * Resolves this `Context`'s settings (fetching any embedded trust-anchor URLs) and serializes
+   * the result for consumption by the native/wasm boundary.
+   *
+   * @param options Optional configurations for fetch-with-retry, used when resolving trust-anchor
+   * URLs.
+   * @returns A JSON-serialized string of the resolved settings.
+   */
+  async toJson(options?: FetchWithRetryOptions): Promise<string> {
+    return resolveSettings(this.settings, options);
+  }
+}

--- a/packages/c2pa-utilities/src/context.ts
+++ b/packages/c2pa-utilities/src/context.ts
@@ -24,10 +24,11 @@ export class Context {
   }
 
   /**
-   * The settings currently attached to this `Context`, if any. To derive a new `Context` with
-   * different settings, construct one with `new Context(settings)` — to combine this `Context`'s
-   * settings with more, merge them with {@link mergeSettings} first and pass the single result to
-   * the constructor.
+   * The settings currently attached to this `Context`, if any.
+   * 
+   * To derive a new `Context` with different settings, construct one with `new Context(settings)`.
+   * To combine this `Context`'s settings with other settings, merge them with {@link mergeSettings}
+   * first and then pass the single, merged result to the constructor to create a new `Context`.
    */
   get settings(): Settings | undefined {
     return this._settings;

--- a/packages/c2pa-utilities/src/context.ts
+++ b/packages/c2pa-utilities/src/context.ts
@@ -11,10 +11,14 @@ import type { FetchWithRetryOptions } from './fetchWithRetry.js';
 import { resolveSettings, type Settings } from './settings.js';
 
 /**
- * A `Context` configures the behavior of a single `Reader`/`Builder`. 
+ * A `Context` configures the behavior of a `Reader`/`Builder`. 
  * 
  * It is provided at creation time (e.g. `Reader.fromBlob(c2pa, format, blob, context)`),
  * configuring that instance's behavior independently of other instances.
+ * 
+ * A `Context` is snapshotted when used to create a `Reader`/`Builder`. Changes to
+ * the context do not propagate afterwards, and therefore can be used to create
+ * multiple `Reader`/`Builder` instances.
  */
 export class Context {
   private readonly _settings?: Settings;
@@ -37,17 +41,26 @@ export class Context {
 
   /**
    * Resolves this `Context`'s settings (fetching any embedded trust-anchor URLs) and serializes
-   * the result for consumption by the WASM/native boundary. The result is memoized, so resolution
-   * of this Context's settings should only ever happen once. If different fetch-with-retry options
-   * need to be provided, callers should create a separate `Context` and then call `toJson()`
-   * with the desired options.
+   * the result for consumption by the WASM/native boundary. A successful result is memoized, so
+   * resolution of this Context's settings only happens once. If different fetch-with-retry
+   * options need to be provided, callers should create a separate `Context` and then call
+   * `toJson()` with the desired options.
+   *
+   * A failed resolution is not memoized: the next call to `toJson()` tries again from scratch,
+   * so a transient failure (e.g. a network error while fetching a trust-anchor URL) doesn't
+   * permanently break this `Context`.
    *
    * @param options Optional configurations for fetch-with-retry, used when resolving trust-anchor
-   * URLs. Only consulted on the first call.
+   * URLs. Only consulted on the first call, or the first call after a previous failure.
    * @returns A JSON-serialized string of the resolved settings.
    */
   toJson(options?: FetchWithRetryOptions): Promise<string> {
-    this._jsonPromise ??= resolveSettings(this.settings, options);
+    this._jsonPromise ??= resolveSettings(this.settings, options).catch(
+      (error: unknown) => {
+        this._jsonPromise = undefined;
+        throw error;
+      }
+    );
     return this._jsonPromise;
   }
 }

--- a/packages/c2pa-utilities/src/context.ts
+++ b/packages/c2pa-utilities/src/context.ts
@@ -11,10 +11,9 @@ import type { FetchWithRetryOptions } from './fetchWithRetry.js';
 import { resolveSettings, type Settings } from './settings.js';
 
 /**
- * A `Context` configures the behavior of every `Reader`/`Builder` created with
- * any given instance of the SDK (see {@link C2paSdk}).
+ * A `Context` configures the behavior of a `Reader` or `Builder`.
  * 
- * It is attached once at SDK/factory-initialization time.
+ * It is attached once at SDK initialization or `Reader`/`Builder` construction time.
  */
 export class Context {
   private readonly _settings?: Settings;

--- a/packages/c2pa-utilities/src/context.ts
+++ b/packages/c2pa-utilities/src/context.ts
@@ -11,23 +11,24 @@ import type { FetchWithRetryOptions } from './fetchWithRetry.js';
 import { resolveSettings, type Settings } from './settings.js';
 
 /**
- * A `Context` configures the behavior of a `Reader` or `Builder`.
- * 
- * It is attached once at SDK initialization or `Reader`/`Builder` construction time.
+ * A `Context` configures the behavior of a single `Reader`/`Builder`. Bindings attach it at
+ * creation time (e.g. `Reader.fromBlob(c2pa, format, blob, context)`), independent of whatever
+ * runtime/worker handle that creation call also needs — so one running SDK instance can freely
+ * create many `Reader`/`Builder`s, each with its own `Context`.
  */
 export class Context {
   private readonly _settings?: Settings;
+  private _jsonPromise?: Promise<string>;
 
   constructor(settings?: Settings) {
     this._settings = settings;
   }
 
   /**
-   * The settings currently attached to this `Context`, if any.
-   * 
-   * To derive a new `Context` with different settings, construct one with `new Context(settings)`.
-   * To combine this `Context`'s settings with other settings, merge them with {@link mergeSettings}
-   * first and then pass the single, merged result to the constructor to create a new `Context`.
+   * The settings currently attached to this `Context`, if any. To derive a new `Context` with
+   * different settings, construct one with `new Context(settings)` — to combine this `Context`'s
+   * settings with more, merge them with {@link mergeSettings} first and pass the single result to
+   * the constructor.
    */
   get settings(): Settings | undefined {
     return this._settings;
@@ -37,11 +38,18 @@ export class Context {
    * Resolves this `Context`'s settings (fetching any embedded trust-anchor URLs) and serializes
    * the result for consumption by the native/wasm boundary.
    *
+   * Memoized: since a `Context`'s settings never change after construction, the result (and any
+   * trust-anchor fetch it took to produce it) is only ever computed once, on the first call, and
+   * reused for every call after — including calls with different `options` than the first one
+   * used. Callers that need the same `Context` resolved under two different `options` should
+   * construct two separate `Context`s instead.
+   *
    * @param options Optional configurations for fetch-with-retry, used when resolving trust-anchor
-   * URLs.
+   * URLs. Only consulted on the first call.
    * @returns A JSON-serialized string of the resolved settings.
    */
-  async toJson(options?: FetchWithRetryOptions): Promise<string> {
-    return resolveSettings(this.settings, options);
+  toJson(options?: FetchWithRetryOptions): Promise<string> {
+    this._jsonPromise ??= resolveSettings(this.settings, options);
+    return this._jsonPromise;
   }
 }

--- a/packages/c2pa-utilities/src/index.ts
+++ b/packages/c2pa-utilities/src/index.ts
@@ -7,6 +7,7 @@
  * it.
  */
 
+export * from './context.js';
 export * from './settings.js';
 export * from './fetchWithRetry.js';
 export * from './caseConversion.js';

--- a/packages/c2pa-utilities/src/settings.spec.ts
+++ b/packages/c2pa-utilities/src/settings.spec.ts
@@ -26,6 +26,7 @@ import {
   mergeSettings,
   settingsToJson,
   loadSettingsFromUrl,
+  withDefaultSettings,
   type TrustSettings,
   type VerifySettings,
   type Settings
@@ -44,80 +45,37 @@ afterAll(() => server.close());
 describe('settings', () => {
   describe('resolveSettings', () => {
     describe('general behavior', () => {
-      test('should return undefined when neither argument is provided', async () => {
-        const result = await resolveSettings(undefined, undefined);
-        expect(result).toBeUndefined();
-      });
-
-      test('should serialize base settings when only base is provided', async () => {
-        const result = await resolveSettings({ verify: { verifyTrust: false } }, undefined);
-        expect(result).toEqual(
-          JSON.stringify({ builder: { generate_c2pa_archive: true }, verify: { verify_trust: false } })
-        );
-      });
-
-      test('should serialize override settings when only override is provided', async () => {
-        const result = await resolveSettings(undefined, { verify: { verifyTrust: false } });
-        expect(result).toEqual(
-          JSON.stringify({ builder: { generate_c2pa_archive: true }, verify: { verify_trust: false } })
-        );
-      });
-
-      test('should accept an empty object as override', async () => {
-        const result = await resolveSettings(undefined, {});
+      test('should still resolve to the package defaults when no settings are provided', async () => {
+        const result = await resolveSettings(undefined);
         expect(result).toEqual(
           JSON.stringify({ builder: { generate_c2pa_archive: true } })
         );
       });
 
-      test('should merge override settings on top of base settings', async () => {
-        const base = {
-          verify: { verifyTrust: true, verifyAfterReading: true }
-        };
-        const override = {
-          verify: { verifyTrust: false }
-        };
-
-        const result = await resolveSettings(base, override);
-
-        // verifyTrust from override wins; verifyAfterReading from base is preserved
+      test('should serialize the given settings', async () => {
+        const result = await resolveSettings({ verify: { verifyTrust: false } });
         expect(result).toEqual(
-          JSON.stringify({
-            builder: { generate_c2pa_archive: true },
-            verify: { verify_trust: false, verify_after_reading: true }
-          })
+          JSON.stringify({ builder: { generate_c2pa_archive: true }, verify: { verify_trust: false } })
         );
       });
 
-      test('should preserve base settings keys not present in override', async () => {
-        const base: Settings = {
-          verify: { verifyAfterReading: false },
-          builder: { generateC2paArchive: true }
-        };
-        const override = {
-          verify: { verifyTrust: true }
-        };
-
-        const result = await resolveSettings(base, override);
-
+      test('should accept an empty settings object', async () => {
+        const result = await resolveSettings({});
         expect(result).toEqual(
-          JSON.stringify({
-            builder: { generate_c2pa_archive: true },
-            verify: { verify_after_reading: false, verify_trust: true }
-          })
+          JSON.stringify({ builder: { generate_c2pa_archive: true } })
         );
       });
 
       test('should not throw when a settings value is null', async () => {
         // typeof null === 'object' in JS — without a null guard this crashes
-        const result = await resolveSettings(undefined, { verify: null as any });
+        const result = await resolveSettings({ verify: null as any });
         expect(result).toEqual(
           JSON.stringify({ builder: { generate_c2pa_archive: true }, verify: null })
         );
       });
 
       test('should not throw when a nested settings value is null', async () => {
-        const result = await resolveSettings(undefined, { trust: { userAnchors: null as any } });
+        const result = await resolveSettings({ trust: { userAnchors: null as any } });
         expect(result).toEqual(
           JSON.stringify({
             builder: { generate_c2pa_archive: true },
@@ -129,7 +87,7 @@ describe('settings', () => {
 
     describe('trust', () => {
       test('should pass through a non-url value', async () => {
-        const result = await resolveSettings(undefined, {
+        const result = await resolveSettings({
           trust: {
             userAnchors: 'foo',
             trustAnchors: 'bar',
@@ -179,7 +137,7 @@ describe('settings', () => {
           http.get('http://trustConfig', () => HttpResponse.text('config'))
         );
 
-        const result = await resolveSettings(undefined, {
+        const result = await resolveSettings({
           trust: {
             userAnchors: 'http://userAnchors',
             trustAnchors: 'http://trustAnchors',
@@ -217,24 +175,6 @@ describe('settings', () => {
         );
       });
 
-      test('should fetch URL trust values from base settings', async () => {
-        server.use(
-          http.get('http://baseTrustAnchors', () =>
-            HttpResponse.text(
-              '-----BEGIN CERTIFICATE-----base-----END CERTIFICATE-----'
-            )
-          )
-        );
-
-        // URL in base settings should be fetched even when override is also present.
-        const result = await resolveSettings(
-          { trust: { trustAnchors: 'http://baseTrustAnchors' } },
-          { verify: { verifyTrust: true } }
-        );
-
-        expect(result).toContain('-----BEGIN CERTIFICATE-----base-----END CERTIFICATE-----');
-      });
-
       test('should concatenate the fetched results of URLs when given as an array', async () => {
         server.use(
           http.get('http://userAnchorsConcat', () =>
@@ -244,7 +184,7 @@ describe('settings', () => {
           )
         );
 
-        const result = await resolveSettings(undefined, {
+        const result = await resolveSettings({
           trust: {
             userAnchors: [
               'http://userAnchorsConcat',
@@ -271,7 +211,7 @@ describe('settings', () => {
           )
         );
 
-        const resultPromise = resolveSettings(undefined, {
+        const resultPromise = resolveSettings({
           trust: {
             userAnchors: 'http://userAnchorsShouldFail'
           }
@@ -296,7 +236,7 @@ describe('settings', () => {
           )
         );
 
-        const result = await resolveSettings(undefined, {
+        const result = await resolveSettings({
           trust: {
             trustAnchors: 'http://trustAnchors',
             ...(({ unknownKey: 'http://unknownKey' }) as any)
@@ -308,7 +248,7 @@ describe('settings', () => {
       });
 
       test('should not crash when a cawgTrust boolean field is present', async () => {
-        const resultPromise = resolveSettings(undefined, {
+        const resultPromise = resolveSettings({
           cawgTrust: {
             verifyTrustList: true
           }
@@ -323,7 +263,7 @@ describe('settings', () => {
           http.get('http://oversized', () => HttpResponse.text(oversizedBody))
         );
 
-        const resultPromise = resolveSettings(undefined, {
+        const resultPromise = resolveSettings({
           trust: {
             trustConfig: 'http://oversized'
           }
@@ -343,7 +283,6 @@ describe('settings', () => {
         );
 
         const resultPromise = resolveSettings(
-          undefined,
           { trust: { trustConfig: 'http://customCap' } },
           { maxResponseBytes: 1024 }
         );
@@ -354,7 +293,7 @@ describe('settings', () => {
       });
 
       test('should reject when an array item is not a string', async () => {
-        const resultPromise = resolveSettings(undefined, {
+        const resultPromise = resolveSettings({
           trust: {
             userAnchors: [123 as unknown as string]
           }
@@ -372,7 +311,7 @@ describe('settings', () => {
           )
         );
 
-        const resultPromise = resolveSettings(undefined, {
+        const resultPromise = resolveSettings({
           trust: {
             userAnchors: ['http://userAnchorsArrayInvalid']
           }
@@ -383,6 +322,21 @@ describe('settings', () => {
         );
       });
 
+    });
+  });
+});
+
+describe('withDefaultSettings', () => {
+  it('applies the package defaults when no settings are given', () => {
+    expect(withDefaultSettings(undefined)).toEqual({
+      builder: { generateC2paArchive: true }
+    });
+  });
+
+  it('merges the given settings on top of the defaults', () => {
+    expect(withDefaultSettings({ verify: { verifyTrust: false } })).toEqual({
+      builder: { generateC2paArchive: true },
+      verify: { verifyTrust: false }
     });
   });
 });

--- a/packages/c2pa-utilities/src/settings.ts
+++ b/packages/c2pa-utilities/src/settings.ts
@@ -34,7 +34,7 @@ import { snakeCaseify, type SettingsObjectType } from './caseConversion.js';
  *   }
  * };
  *
- * const settingsJson = await resolveSettings(settings, undefined);
+ * const settingsJson = await resolveSettings(settings);
  * ```
  */
 export interface Settings {
@@ -150,40 +150,49 @@ export interface BuilderSettings {
 // Defaults
 // =================================
 
-const DEFAULT_SETTINGS: Settings = {
+/**
+ * This package's default settings, applied by {@link withDefaultSettings} and
+ * {@link resolveSettings} so a `Reader`/`Builder` gets sane behavior even with no settings
+ * provided at all.
+ */
+export const DEFAULT_SETTINGS: Settings = {
   builder: {
     generateC2paArchive: true
   }
 };
+
+/**
+ * Merges `settings` on top of this package's default settings.
+ * Useful for bindings that need this package's defaults applied without going through
+ * {@link resolveSettings}'s async trust-anchor URL resolution.
+ *
+ * @param settings Settings to apply the defaults to.
+ * @returns `settings` merged on top of this package's defaults.
+ */
+export function withDefaultSettings(settings: Settings | undefined): Settings {
+  return merge(DEFAULT_SETTINGS, settings ?? {});
+}
 
 // =================================
 // Top-level pipeline
 // =================================
 
 /**
- * Resolves settings by merging override settings on top of base settings, resolving any embedded
- * trust list URLs on top of those, and then finally serializing the result for consumption by the core native SDK.
+ * Resolves settings by resolving any embedded trust-anchor URLs, then serializing the result for
+ * consumption by the core native SDK. `settings` is merged on top of this package's default
+ * settings (see {@link withDefaultSettings}). To combine more than one `Settings` source, merge them with
+ * {@link mergeSettings} first and pass the single result in here.
  *
- * @param baseSettings Settings established at SDK initialization time.
- * @param overrideSettings Optional override settings. Keys present in overrideSettings win over keys in baseSettings.
+ * @param settings Settings to resolve.
  * @param options Optional configurations for fetch-with-retry.
- * @returns A JSON-serialized string containing all resolved settings values, ready to be consumed by the core native SDK.
- * Returns undefined when neither argument is provided.
+ * @returns A JSON-serialized string containing all resolved settings values, ready to be consumed
+ * by the core native SDK.
  */
 export async function resolveSettings(
-  baseSettings: Settings | undefined,
-  overrideSettings: Settings | undefined,
+  settings: Settings | undefined,
   options?: FetchWithRetryOptions
-): Promise<string | undefined> {
-  const effectiveSettings = overrideSettings
-    ? merge(baseSettings ?? {}, overrideSettings)
-    : baseSettings;
-
-  if (!effectiveSettings) {
-    return undefined;
-  }
-
-  const finalSettings: Settings = merge(DEFAULT_SETTINGS, effectiveSettings);
+): Promise<string> {
+  const finalSettings: Settings = withDefaultSettings(settings);
 
   const resolvePromises: Promise<void>[] = [];
 

--- a/packages/c2pa-utilities/src/settings.ts
+++ b/packages/c2pa-utilities/src/settings.ts
@@ -155,11 +155,11 @@ export interface BuilderSettings {
  * {@link resolveSettings} so a `Reader`/`Builder` gets sane behavior even with no settings
  * provided at all.
  */
-export const DEFAULT_SETTINGS: Settings = {
-  builder: {
+export const DEFAULT_SETTINGS: Readonly<Settings> = Object.freeze({
+  builder: Object.freeze({
     generateC2paArchive: true
-  }
-};
+  })
+});
 
 /**
  * Merges `settings` on top of this package's default settings.

--- a/packages/c2pa-web/src/lib/builder.ts
+++ b/packages/c2pa-web/src/lib/builder.ts
@@ -17,7 +17,7 @@ import type {
   Ingredient,
   ManifestDefinition
 } from '@contentauth/c2pa-types';
-import { Settings, resolveSettings } from '@contentauth/c2pa-utilities';
+import { mergeSettings, Settings, resolveSettings } from '@contentauth/c2pa-utilities';
 
 /**
  * Functions that permit the creation of Builder objects.
@@ -304,7 +304,11 @@ export function createBuilderFactory(worker: WorkerManager, settings?: Settings)
 
   return {
     async new(settings?: Settings) {
-      const settingsJson = await resolveSettings(baseSettings, settings);
+      // TODO: temporary shim for c2pa-utilities' resolveSettings signature change
+      // (single-argument now); removed once c2pa-web adopts Context in a follow-up PR.
+      const settingsJson = await resolveSettings(
+        settings ? mergeSettings(baseSettings ?? {}, settings) : baseSettings
+      );
       const builderId = await tx.builder_new(settingsJson);
 
       const builder = createBuilder(worker, builderId, () => {
@@ -317,7 +321,11 @@ export function createBuilderFactory(worker: WorkerManager, settings?: Settings)
 
     async fromDefinition(definition: ManifestDefinition, settings?: Settings) {
       const json = JSON.stringify(definition);
-      const settingsJson = await resolveSettings(baseSettings, settings);
+      // TODO: temporary shim for c2pa-utilities' resolveSettings signature change
+      // (single-argument now); removed once c2pa-web adopts Context in a follow-up PR.
+      const settingsJson = await resolveSettings(
+        settings ? mergeSettings(baseSettings ?? {}, settings) : baseSettings
+      );
       const builderId = await tx.builder_fromJson(json, settingsJson);
 
       const builder = createBuilder(worker, builderId, () => {
@@ -329,7 +337,11 @@ export function createBuilderFactory(worker: WorkerManager, settings?: Settings)
     },
 
     async fromArchive(archive: Blob, settings?: Settings) {
-      const settingsJson = await resolveSettings(baseSettings, settings);
+      // TODO: temporary shim for c2pa-utilities' resolveSettings signature change
+      // (single-argument now); removed once c2pa-web adopts Context in a follow-up PR.
+      const settingsJson = await resolveSettings(
+        settings ? mergeSettings(baseSettings ?? {}, settings) : baseSettings
+      );
       const builderId = await tx.builder_fromArchive(archive, settingsJson);
 
       const builder = createBuilder(worker, builderId, () => {

--- a/packages/c2pa-web/src/lib/c2pa.ts
+++ b/packages/c2pa-web/src/lib/c2pa.ts
@@ -70,7 +70,7 @@ export async function createC2pa(config: Config): Promise<C2paSdk> {
   const wasm =
     typeof wasmSrc === 'string' ? await fetchAndCompileWasm(wasmSrc) : wasmSrc;
 
-  const settingsString = await resolveSettings(settings, undefined);
+  const settingsString = await resolveSettings(settings);
   const worker = await createWorkerManager({ wasm, workerSrc, settingsString });
 
   return {

--- a/packages/c2pa-web/src/lib/reader.ts
+++ b/packages/c2pa-web/src/lib/reader.ts
@@ -12,6 +12,7 @@ import { UnsupportedFormatError } from './error.js';
 import { isSupportedReaderFormat } from './supportedFormats.js';
 import type { WorkerManager } from './worker/workerManager.js';
 import {
+  mergeSettings,
   Settings,
   resolveSettings,
   validateAssetSize
@@ -141,7 +142,11 @@ export function createReaderFactory(worker: WorkerManager, settings?: Settings):
       validateAssetSize(blob.size, MAX_SIZE_IN_BYTES);
 
       try {
-        const settingsJson = await resolveSettings(baseSettings, settings);
+        // TODO: temporary shim for c2pa-utilities' resolveSettings signature change
+        // (single-argument now); removed once c2pa-web adopts Context in a follow-up PR.
+        const settingsJson = await resolveSettings(
+          settings ? mergeSettings(baseSettings ?? {}, settings) : baseSettings
+        );
 
         const readerId = await tx.reader_fromBlob(format, blob, settingsJson);
 
@@ -170,7 +175,11 @@ export function createReaderFactory(worker: WorkerManager, settings?: Settings):
       validateAssetSize(fragment.size, MAX_SIZE_IN_BYTES);
 
       try {
-        const settingsJson = await resolveSettings(baseSettings, settings);
+        // TODO: temporary shim for c2pa-utilities' resolveSettings signature change
+        // (single-argument now); removed once c2pa-web adopts Context in a follow-up PR.
+        const settingsJson = await resolveSettings(
+          settings ? mergeSettings(baseSettings ?? {}, settings) : baseSettings
+        );
 
         const readerId = await tx.reader_fromBlobFragment(
           format,


### PR DESCRIPTION
## Summary
This PR introduces the `Context` class, mirroring the one used in native SDKs, as a wrapper around `Settings` for configuring `Reader` and `Builder` objects. This class is adopted by `c2pa-web` in https://github.com/contentauth/c2pa-js/pull/202 and by `c2pa-node` in https://github.com/contentauth/c2pa-js/pull/204 as the new way to configure SDK behavior.

The changes in this PR are considered **breaking changes**.

## Changes
- Added a `Context` class wrapping `Settings`, mirroring `Context` used in native SDKs.
  - `Context` is immutable and is meant to supplied when creating a `Reader` or `Builder`, customizing that instance's behavior.
- Simplified `resolveSettings` by no longer accepting overrides, since the concept of providing per-call overrides no longer applies. Users should create and merge their settings as needed, then pass them into a `Context` that goes into the `Reader` or `Builder` that they wish to configure.
  - Added temporary shims in `c2pa-web` to accommodate the signature change; will be removed in https://github.com/contentauth/c2pa-js/pull/202.
- Added `withDefaultSettings()`, a synchronous counterpart to `resolveSettings` that applies this package's defaults without the async trust-anchor URL resolution, for use in `c2pa-node` which needs the defaults without supporting that fetch (yet).
