### PR TITLE
fix: Remove redundant archive-metadata assertion filtering

### DIFF
--- a/.changeset/flat-vans-mate.md
+++ b/.changeset/flat-vans-mate.md
@@ -1,0 +1,6 @@
+---
+'@contentauth/c2pa-node': patch
+'@contentauth/c2pa-wasm': patch
+---
+
+Remove redundant archive-metadata assertion filtering

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,20 @@ permissions:
   contents: read
 
 jobs:
+  cargo_fmt:
+    name: Enforce Rust code format
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install nightly toolchain
+        uses: dtolnay/rust-toolchain@nightly
+        with:
+          components: rustfmt
+
+      - name: Check format
+        run: cargo +nightly fmt --all -- --check
+
   main:
     runs-on: ubuntu-24.04
     steps:

--- a/packages/c2pa-node/src/asset.rs
+++ b/packages/c2pa-node/src/asset.rs
@@ -11,13 +11,15 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use crate::error::Error;
-use c2pa::format_from_path;
-use neon::prelude::*;
-use neon::types::buffer::TypedArray;
 use std::fs::{File, OpenOptions};
 use std::io::{BufReader, Cursor, Read, Seek, Write};
 use std::path::Path;
+
+use c2pa::format_from_path;
+use neon::prelude::*;
+use neon::types::buffer::TypedArray;
+
+use crate::error::Error;
 
 pub(crate) trait NeonReadStreamTrait: Read + Seek + Send {}
 pub(crate) trait NeonWriteStreamTrait: Write + Read + Seek + Send {}

--- a/packages/c2pa-node/src/neon_builder.rs
+++ b/packages/c2pa-node/src/neon_builder.rs
@@ -11,6 +11,20 @@
 // specific language governing permissions and limitations under
 // each license.
 
+use std::io::Cursor;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use c2pa::{
+    assertions::{Action, Actions},
+    Builder, BuilderIntent, Ingredient, Reader,
+};
+use neon::context::Context as NeonContext;
+use neon::prelude::*;
+use neon_serde4;
+use serde_json;
+use tokio::sync::Mutex;
+
 use crate::asset::parse_asset;
 use crate::error::{as_js_error, Error};
 use crate::neon_identity_assertion_signer::NeonIdentityAssertionSigner;
@@ -18,15 +32,6 @@ use crate::neon_reader::NeonReader;
 use crate::neon_signer::{CallbackSignerConfig, NeonCallbackSigner, NeonLocalSigner};
 use crate::runtime::runtime;
 use crate::utils::parse_settings;
-use c2pa::{assertions::{Action, Actions}, Builder, BuilderIntent, Ingredient, Reader};
-use neon::context::Context as NeonContext;
-use neon::prelude::*;
-use neon_serde4;
-use serde_json;
-use std::io::Cursor;
-use std::ops::Deref;
-use std::sync::Arc;
-use tokio::sync::Mutex;
 
 pub struct NeonBuilder {
     builder: Arc<Mutex<Builder>>,
@@ -324,17 +329,11 @@ impl NeonBuilder {
         let promise = cx
             .task(move || {
                 let source_stream = source.into_read_stream()?;
-                let mut builder = if let Some(context) = context_opt {
+                let builder = if let Some(context) = context_opt {
                     Builder::from_context(context).with_archive(source_stream)?
                 } else {
                     Builder::default().with_archive(source_stream)?
                 };
-                // The ARCHIVE_METADATA assertion is merely working-store bookkeeping
-                // used to reconstruct a builder from an archive.
-                builder
-                    .definition
-                    .assertions
-                    .retain(|a| a.label != c2pa::assertions::labels::ARCHIVE_METADATA);
                 Ok(builder)
             })
             .promise(

--- a/packages/c2pa-node/src/neon_credential_holder.rs
+++ b/packages/c2pa-node/src/neon_credential_holder.rs
@@ -11,13 +11,14 @@
 // specific language governing permissions and limitations under
 // each license.
 
+use std::sync::Arc;
+
 use async_trait::async_trait;
 use c2pa::identity::builder::{AsyncCredentialHolder, IdentityBuilderError};
 use c2pa::identity::SignerPayload;
 use neon::prelude::*;
 use neon::types::buffer::TypedArray;
 use neon_serde4;
-use std::sync::Arc;
 use tokio::sync::oneshot;
 
 /// NeonCallbackCredentialHolder allows JS to asynchronously sign a SignerPayload.

--- a/packages/c2pa-node/src/neon_identity_assertion_builder.rs
+++ b/packages/c2pa-node/src/neon_identity_assertion_builder.rs
@@ -11,7 +11,9 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use crate::neon_credential_holder::NeonCallbackCredentialHolder;
+use std::ops::Deref;
+use std::sync::RwLock;
+
 use c2pa::{
     dynamic_assertion::{AsyncDynamicAssertion, DynamicAssertionContent},
     identity::{builder::AsyncCredentialHolder, SignerPayload},
@@ -19,8 +21,8 @@ use c2pa::{
 use neon::prelude::*;
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
-use std::ops::Deref;
-use std::sync::RwLock;
+
+use crate::neon_credential_holder::NeonCallbackCredentialHolder;
 
 /// A `NeonIdentityAssertionBuilder` gathers the necessary components
 /// for an identity assertion using a Neon-based credential holder.

--- a/packages/c2pa-node/src/neon_identity_assertion_signer.rs
+++ b/packages/c2pa-node/src/neon_identity_assertion_signer.rs
@@ -11,9 +11,9 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use crate::{
-    neon_identity_assertion_builder::NeonIdentityAssertionBuilder, neon_signer::NeonCallbackSigner,
-};
+use std::ops::Deref;
+use std::sync::RwLock;
+
 use async_trait::async_trait;
 use c2pa::{
     crypto::{
@@ -25,8 +25,10 @@ use c2pa::{
 };
 use neon::prelude::FunctionContext;
 use neon::prelude::*;
-use std::ops::Deref;
-use std::sync::RwLock;
+
+use crate::{
+    neon_identity_assertion_builder::NeonIdentityAssertionBuilder, neon_signer::NeonCallbackSigner,
+};
 
 pub struct NeonIdentityAssertionSigner {
     signer: RwLock<NeonCallbackSigner>,

--- a/packages/c2pa-node/src/neon_reader.rs
+++ b/packages/c2pa-node/src/neon_reader.rs
@@ -11,16 +11,18 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use crate::asset::parse_asset;
-use crate::error::{as_js_error, Error, Result};
-use crate::runtime::runtime;
-use crate::utils::parse_settings;
+use std::sync::Arc;
+
 use c2pa::Reader;
 use neon::context::Context as NeonContext;
 use neon::prelude::*;
 use neon::types::buffer::TypedArray;
-use std::sync::Arc;
 use tokio::sync::Mutex;
+
+use crate::asset::parse_asset;
+use crate::error::{as_js_error, Error, Result};
+use crate::runtime::runtime;
+use crate::utils::parse_settings;
 
 #[derive(Debug)]
 pub struct NeonReader {

--- a/packages/c2pa-node/src/neon_signer.rs
+++ b/packages/c2pa-node/src/neon_signer.rs
@@ -11,7 +11,9 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use crate::runtime::runtime;
+use std::ops::Deref;
+use std::{boxed::Box, str::FromStr, sync::Arc};
+
 use async_trait::async_trait;
 use c2pa::{
     create_signer,
@@ -25,11 +27,10 @@ use c2pa::{
 };
 use neon::prelude::*;
 use neon::types::buffer::TypedArray;
-use std::ops::Deref;
-use std::{boxed::Box, str::FromStr, sync::Arc};
 use tokio::sync::oneshot;
 
 use crate::error::Error;
+use crate::runtime::runtime;
 
 #[derive(Debug, Clone)]
 pub struct CallbackSignerConfig {

--- a/packages/c2pa-node/src/neon_trustmark.rs
+++ b/packages/c2pa-node/src/neon_trustmark.rs
@@ -11,13 +11,6 @@
 // specific language governing permissions and limitations under
 // each license.
 
-use crate::error::{as_js_error, as_js_error_fn, Error, Result};
-use crate::runtime::runtime;
-use neon::prelude::*;
-use neon::result::{JsResult, NeonResult};
-use neon::types::{buffer::TypedArray, Finalize, JsObject};
-use rand::{distributions::Standard, prelude::Distribution as _};
-use reqwest::Client;
 use std::{
     fs::OpenOptions,
     io::Write,
@@ -25,7 +18,16 @@ use std::{
     sync::{Arc, Mutex},
     time::Duration,
 };
+
+use neon::prelude::*;
+use neon::result::{JsResult, NeonResult};
+use neon::types::{buffer::TypedArray, Finalize, JsObject};
+use rand::{distributions::Standard, prelude::Distribution as _};
+use reqwest::Client;
 use trustmark::{Trustmark, Variant, Version};
+
+use crate::error::{as_js_error, as_js_error_fn, Error, Result};
+use crate::runtime::runtime;
 
 #[derive(Clone)]
 pub struct WatermarkConfig {

--- a/packages/c2pa-node/src/runtime.rs
+++ b/packages/c2pa-node/src/runtime.rs
@@ -6,6 +6,7 @@
 // it.
 
 use std::sync::{Arc, OnceLock};
+
 use tokio::runtime::{Builder, Runtime};
 
 // Runtime singleton - no longer needs reload functionality since settings are per-instance

--- a/packages/c2pa-node/src/utils.rs
+++ b/packages/c2pa-node/src/utils.rs
@@ -49,7 +49,7 @@ pub fn parse_settings(
                     .downcast::<JsString, _>(cx)
                     .map_err(|_| {
                         Error::Signing(format!("{error_prefix}: Expected settings string"))
-                    })? 
+                    })?
                     .value(cx);
 
                 // Create context with settings

--- a/packages/c2pa-wasm/src/stream/blob_stream.rs
+++ b/packages/c2pa-wasm/src/stream/blob_stream.rs
@@ -62,9 +62,7 @@ fn read_entire_blob(blob: &Blob) -> IoResult<Vec<u8>> {
     }
 
     let reader_sync = FileReaderSync::new().map_err(|err| {
-        IoError::other(format!(
-            "Failed to create FileReaderSync. Details: {err:?}"
-        ))
+        IoError::other(format!("Failed to create FileReaderSync. Details: {err:?}"))
     })?;
 
     let array_buffer = reader_sync
@@ -131,12 +129,12 @@ impl Seek for BlobStream {
                     SeekFrom::Start(o) => i64::try_from(o).map_err(|_| {
                         IoError::new(std::io::ErrorKind::InvalidInput, "seek overflow")
                     })?,
-                    SeekFrom::End(o) => (blob.size() as i64)
-                        .checked_add(o)
-                        .ok_or_else(|| IoError::new(std::io::ErrorKind::InvalidInput, "seek overflow"))?,
-                    SeekFrom::Current(o) => (*offset as i64)
-                        .checked_add(o)
-                        .ok_or_else(|| IoError::new(std::io::ErrorKind::InvalidInput, "seek overflow"))?,
+                    SeekFrom::End(o) => (blob.size() as i64).checked_add(o).ok_or_else(|| {
+                        IoError::new(std::io::ErrorKind::InvalidInput, "seek overflow")
+                    })?,
+                    SeekFrom::Current(o) => (*offset as i64).checked_add(o).ok_or_else(|| {
+                        IoError::new(std::io::ErrorKind::InvalidInput, "seek overflow")
+                    })?,
                 };
                 if new_offset < 0 {
                     return Err(IoError::new(

--- a/packages/c2pa-wasm/src/wasm_builder.rs
+++ b/packages/c2pa-wasm/src/wasm_builder.rs
@@ -99,7 +99,7 @@ impl WasmBuilder {
         context_json: Option<String>,
     ) -> Result<WasmBuilder, JsString> {
         let stream = BlobStream::new(archive).map_err(WasmError::other)?;
-        let mut builder = if let Some(ctx_json) = context_json {
+        let builder = if let Some(ctx_json) = context_json {
             let context = Context::new()
                 .with_settings(ctx_json.as_str())
                 .map_err(WasmError::from)?;
@@ -107,15 +107,10 @@ impl WasmBuilder {
                 .with_archive(stream)
                 .map_err(WasmError::from)?
         } else {
-            Builder::default().with_archive(stream).map_err(WasmError::from)?
+            Builder::default()
+                .with_archive(stream)
+                .map_err(WasmError::from)?
         };
-
-        // The ARCHIVE_METADATA assertion is merely working-store bookkeeping used to
-        // reconstruct a builder from an archive.
-        builder
-            .definition
-            .assertions
-            .retain(|a| a.label != c2pa::assertions::labels::ARCHIVE_METADATA);
 
         Ok(WasmBuilder::from_builder(builder))
     }
@@ -253,7 +248,8 @@ impl WasmBuilder {
         self.builder
             .filter_actions_and_ingredients(
                 |_action| {
-                    let keep = u32::try_from(action_i).is_ok_and(|idx| action_indices.contains(&idx));
+                    let keep =
+                        u32::try_from(action_i).is_ok_and(|idx| action_indices.contains(&idx));
                     action_i += 1;
                     keep
                 },
@@ -319,9 +315,8 @@ impl WasmBuilder {
         let mut rewritten: Vec<(usize, Option<serde_json::Value>)> =
             Vec::with_capacity(positions.len());
         for (pos, group) in positions.into_iter().zip(action_groups) {
-            let value =
-                serde_json::to_value(&self.builder.definition.assertions[pos].data)
-                    .map_err(WasmError::other)?;
+            let value = serde_json::to_value(&self.builder.definition.assertions[pos].data)
+                .map_err(WasmError::other)?;
             let mut actions: Actions = serde_json::from_value(value).map_err(WasmError::other)?;
 
             if group.is_empty() {


### PR DESCRIPTION
c2pa-rs now strips the ARCHIVE_METADATA assertion itself when constructing a builder from an archive, so the manual retain() filters in wasm_builder.rs and neon_builder.rs are dead code; remove them. Reformat the workspace with `cargo +nightly fmt --all` and add a CI job enforcing that check going forward.

https://github.com/contentauth/c2pa-rs/pull/2374