### PR TITLE
fix(c2pa-node): Switch `fs-extra` to default import from namespace import

### DIFF
--- a/.changeset/chubby-rats-happen.md
+++ b/.changeset/chubby-rats-happen.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-node': patch
+---
+
+Switch fs-extra import from namespace import to default import.

--- a/packages/c2pa-node/js-src/Builder.spec.ts
+++ b/packages/c2pa-node/js-src/Builder.spec.ts
@@ -14,7 +14,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import type { Manifest, ResourceRef } from "@contentauth/c2pa-types";
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import path from "path";
 import * as crypto from "crypto";
 

--- a/packages/c2pa-node/js-src/IdentityAssertion.spec.ts
+++ b/packages/c2pa-node/js-src/IdentityAssertion.spec.ts
@@ -14,7 +14,7 @@
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
 
 import type { Manifest } from "@contentauth/c2pa-types";
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import * as crypto from "crypto";
 import { encode } from "cbor2";
 

--- a/packages/c2pa-node/js-src/Reader.spec.ts
+++ b/packages/c2pa-node/js-src/Reader.spec.ts
@@ -15,7 +15,7 @@
 // import native objects from built native code
 import type { ManifestStore } from "@contentauth/c2pa-types";
 import path from "path";
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import { AssetTooLargeError } from "@contentauth/c2pa-utilities";
 
 import { Reader } from "./Reader.js";

--- a/packages/c2pa-node/js-src/Settings.spec.ts
+++ b/packages/c2pa-node/js-src/Settings.spec.ts
@@ -4,7 +4,7 @@
 // or the MIT license (http://opensource.org/licenses/MIT),
 // at your option.
 
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import * as path from "path";
 import * as os from "os";
 

--- a/packages/c2pa-node/js-src/Settings.ts
+++ b/packages/c2pa-node/js-src/Settings.ts
@@ -11,7 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 
 /**
  * This file contains only Settings functions that are unique to the Node SDK.

--- a/packages/c2pa-node/js-src/Signer.spec.ts
+++ b/packages/c2pa-node/js-src/Signer.spec.ts
@@ -12,7 +12,7 @@
 // each license.
 
 /* eslint-disable @typescript-eslint/no-non-null-assertion */
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import * as crypto from "crypto";
 
 import { CallbackSigner } from "./Signer.js";

--- a/packages/c2pa-node/js-src/Trustmark.spec.ts
+++ b/packages/c2pa-node/js-src/Trustmark.spec.ts
@@ -12,7 +12,7 @@
 // each license.
 
 import path from "path";
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import sharp from "sharp";
 
 import { Trustmark } from "./Trustmark.js";

--- a/packages/c2pa-node/js-src/assetSize.ts
+++ b/packages/c2pa-node/js-src/assetSize.ts
@@ -11,7 +11,7 @@
 // specific language governing permissions and limitations under
 // each license.
 
-import * as fs from "fs-extra";
+import fs from "fs-extra";
 import { validateAssetSize } from "@contentauth/c2pa-utilities";
 import type { SourceAsset } from "./types.d.ts";
 


### PR DESCRIPTION
This PR switches the `fs-extra` import in `c2pa-node` to use a default import pattern rather than a namespace import, which makes it so that it gets the module's actual `module.exports` object instead of a synthetic namespace built from statically-detected named exports. This gap breaks calls like `fs.stat()` in `c2pa-node` at actual runtime, and was not caught by Vitest's testing envrionment.