### PR TITLE
chore: c2pa-rs version bump to v0.90.19.

### DIFF
--- a/.changeset/tough-wolves-serve.md
+++ b/.changeset/tough-wolves-serve.md
@@ -1,0 +1,7 @@
+---
+'@contentauth/c2pa-node': patch
+'@contentauth/c2pa-wasm': patch
+'@contentauth/c2pa-web': patch
+---
+
+c2pa-rs version bump to v0.90.19

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "c2pa"
-version = "0.90.16"
+version = "0.90.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c736cd424ccd6f63204a037bc12fb6919dcebc01b884d7d3d2c3eed11e6548c"
+checksum = "3125e280280769aa4c1e0be7d484105e93de41c5f3158ec93c0e9be13eadeb03"
 dependencies = [
  "asn1-rs",
  "async-generic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-c2pa = { version = "=0.90.16", features = ["unstable_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
+c2pa = { version = "=0.90.19", features = ["unstable_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
https://github.com/contentauth/c2pa-rs/releases/tag/c2pa-v0.90.19

Full changelog: https://github.com/contentauth/c2pa-rs/compare/c2pa-v0.90.16...c2pa-v0.90.19