### PR TITLE
chore: update c2pa-rs v0.90.16->v0.90.20

### DIFF
--- a/.changeset/slimy-jokes-like.md
+++ b/.changeset/slimy-jokes-like.md
@@ -1,0 +1,7 @@
+---
+'@contentauth/c2pa-node': patch
+'@contentauth/c2pa-wasm': patch
+'@contentauth/c2pa-web': patch
+---
+
+c2pa-rs version bump to v0.90.20

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -481,9 +481,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "c2pa"
-version = "0.90.16"
+version = "0.90.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c736cd424ccd6f63204a037bc12fb6919dcebc01b884d7d3d2c3eed11e6548c"
+checksum = "90af5aa56db6deaeb69722c3955f0cee32c87e95674f433c8926d0339d1f9c9b"
 dependencies = [
  "asn1-rs",
  "async-generic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,17 +1,20 @@
 
 [workspace]
 resolver = '2'
-members = [
-	'packages/c2pa-wasm',
-	'packages/c2pa-types',
-	'packages/c2pa-node',
-]
+members = ['packages/c2pa-wasm', 'packages/c2pa-types', 'packages/c2pa-node']
 
 [workspace.package]
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-c2pa = { version = "=0.90.16", features = ["unstable_builder_filter", "pdf", "rust_native_crypto", "fetch_remote_manifests", "json_schema", "http_reqwest"], default-features = false }
+c2pa = { version = "=0.90.20", features = [
+    "unstable_builder_filter",
+    "pdf",
+    "rust_native_crypto",
+    "fetch_remote_manifests",
+    "json_schema",
+    "http_reqwest",
+], default-features = false }
 
 [profile.release]
 opt-level = "s"


### PR DESCRIPTION
Update c2pa-rs to v0.90.20. Supersedes #210.