### PR TITLE
fix(c2pa-web): Incomplete sanitization of manifest store labels

### DIFF
--- a/.changeset/chubby-mammals-exist.md
+++ b/.changeset/chubby-mammals-exist.md
@@ -1,0 +1,5 @@
+---
+'@contentauth/c2pa-web': patch
+---
+
+Fix sanitization of manifest store.

--- a/packages/c2pa-web/src/lib/worker/sanitizeManifestStore.spec.ts
+++ b/packages/c2pa-web/src/lib/worker/sanitizeManifestStore.spec.ts
@@ -65,4 +65,21 @@ describe('sanitizeManifestStore', () => {
     expect(result.manifests['__proto__']).toBe(activeManifest);
     expect(result.manifests['urn:c2pa:sibling']).toBe(siblingManifest);
   });
+
+  test('does not clobber the active manifest when the "__proto__"-labeled manifest is not active', () => {
+    const activeManifest = { title: 'active' };
+    const poisonedManifest = { title: 'FORGED' };
+
+    const poisoned: Record<string, unknown> = {
+      'urn:c2pa:genuine': activeManifest
+    };
+    // eslint-disable-next-line no-proto
+    (poisoned as any).__proto__ = poisonedManifest;
+
+    const store = { active_manifest: 'urn:c2pa:genuine', manifests: poisoned };
+    const result = sanitizeManifestStore(store);
+
+    expect(result.manifests[result.active_manifest]).toBe(activeManifest);
+    expect(result.manifests['__proto__']).toBe(poisonedManifest);
+  });
 });

--- a/packages/c2pa-web/src/lib/worker/sanitizeManifestStore.ts
+++ b/packages/c2pa-web/src/lib/worker/sanitizeManifestStore.ts
@@ -18,6 +18,12 @@
  * copies own properties, so it would disappear in transit. We detect this by
  * checking whether the prototype was changed, and restore the manifest as an
  * own property before the value leaves the worker.
+ *
+ * The recovered value's key is always the literal string "__proto__" -
+ * that's the only key whose bracket assignment triggers [[SetPrototypeOf]] -
+ * regardless of which manifest is active. It must be restored under that
+ * key rather than `store.active_manifest`, otherwise a poisoned manifest
+ * that isn't the active one would overwrite the genuine active manifest.
  */
 export function sanitizeManifestStore(store: any): any {
   if (!store?.manifests) {
@@ -28,8 +34,8 @@ export function sanitizeManifestStore(store: any): any {
   const sanitizedManifests = Object.assign(Object.create(null), rawManifests);
 
   const proto = Object.getPrototypeOf(rawManifests);
-  if (proto !== null && proto !== Object.prototype && store.active_manifest) {
-    sanitizedManifests[store.active_manifest] = proto;
+  if (proto !== null && proto !== Object.prototype) {
+    sanitizedManifests['__proto__'] = proto;
   }
 
   store.manifests = sanitizedManifests;


### PR DESCRIPTION
This PR follows up on #145's fix, which was incomplete. 

In this PR:
- The sanitized manifest store now avoids clobbering the active manifest when it finds the bad `__proto__` label by re-assigning it in-place, rather than assigning the sanitized manifest over the active one.
- Add unit test to verify the above case.